### PR TITLE
refactor-책추천의 검색 위치수정 (#55)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import ClubSearchPage from "./pages/Main/ClubSearchPage"; // 북클럽 검색
 import CreateClubPage from "./pages/Main/CreateClubPage";
 import BookStorySearchPage from "./pages/Main/BookStory/BookStorySearchPage";
 import SearchPage from "./pages/Main/SearchPage";
-import BookAddPage from "./pages/BookClub/Review/BookAddPage";
+import SearchRecommendBookPage from "./pages/BookRecommend/SearchRecommendBookPage"
 import ShelfHomePage from "./pages/BookClub/Shelf/ShelfHomePage";
 import ShelfDetailPage from "./pages/BookClub/Shelf/ShelfDetailPage";
 import ThemeDetailPage from "./pages/BookClub/Shelf/ThemeDetailPage";
@@ -87,12 +87,15 @@ const App = () => {
             {/* 동적 모임 - 사이드바 확인용 (더기)  */}
             <Route path=":id" element={<BookClubLayout />}>
               <Route path="home" element={<BookClubHomePage />} />
-              <Route path="bookaddpage" element={<BookAddPage />} />
 
+              {/* 책장 */}
               <Route path="shelf" element={<ShelfHomePage />} />
               <Route path="shelf/:shelfBookIndex" element={<ShelfDetailPage />} />
               <Route path="shelf/:shelfBookIndex/theme" element={<ThemeDetailPage />} />
               <Route path="shelf/:shelfBookIndex/score" element={<ScoreDetailPage />} />  
+
+              {/* 책 추천 */}
+              <Route path="recommend/searchrecommendbook" element={<SearchRecommendBookPage />} />
             </Route>
           </Route>
           <Route path="/test-header" element={<TestHeaderPage />} />

--- a/src/pages/BookClub/Review/EditPage.tsx
+++ b/src/pages/BookClub/Review/EditPage.tsx
@@ -1,9 +1,0 @@
-
-
-const EditPage = () => {
-  return (
-    <div>EditPage</div>
-  )
-}
-
-export default EditPage

--- a/src/pages/BookClub/Review/HomePage.tsx
+++ b/src/pages/BookClub/Review/HomePage.tsx
@@ -1,9 +1,0 @@
-
-
-const HomePage = () => {
-  return (
-    <div>HomePage</div>
-  )
-}
-
-export default HomePage

--- a/src/pages/BookRecommend/SearchRecommendBookPage.tsx
+++ b/src/pages/BookRecommend/SearchRecommendBookPage.tsx
@@ -1,11 +1,11 @@
-//BookAddPage.tsx
+//SearchRecommendBookPage.tsx
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-import BookSearch, { type Book, type Action } from '../../../components/Search/BookSearch'
+import BookSearch, { type Book, type Action } from '../../components/Search/BookSearch'
 import { useParams } from 'react-router-dom'
-import Header from '../../../components/Header'
+import Header from '../../components/Header'
 
-export default function BookAddPage() {
+export default function SearchRecommendBookPage() {
   const navigate = useNavigate()
    const { id } = useParams<{ id: string }>()
 


### PR DESCRIPTION
책 추천에서 사용할 검색에 대한 페이지

파일 위치를 BookRecommend로 옮기며, 이름을 수정했고 
라우터를 recommend/searchrecommendbook로 두었습니다.

책 추천의 라우터는 bookclub/:id/reccommend/ ~ 가 될 예정이며 나중에 오즈님이 만들어진 페이지 라우터 수정하시면서 연결시켜 주시면 될 것 같습니다!

책추천은 오즈님 독자적으로 개발하는 파트라 오즈님이 보시고 바로 PR눌러주시면 될 거 같습니다.