### PR TITLE
Style-Shelf페이지 UI 세부사항 완성 (#58)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import ClubSearchPage from "./pages/Main/ClubSearchPage"; // 북클럽 검색
 import CreateClubPage from "./pages/Main/CreateClubPage";
 import BookStorySearchPage from "./pages/Main/BookStory/BookStorySearchPage";
 import SearchPage from "./pages/Main/SearchPage";
-import BookAddPage from "./pages/BookClub/Review/BookAddPage";
+import SearchRecommendBookPage from "./pages/BookRecommend/SearchRecommendBookPage"
 import ShelfHomePage from "./pages/BookClub/Shelf/ShelfHomePage";
 import ShelfDetailPage from "./pages/BookClub/Shelf/ShelfDetailPage";
 import ThemeDetailPage from "./pages/BookClub/Shelf/ThemeDetailPage";
@@ -87,12 +87,15 @@ const App = () => {
             {/* 동적 모임 - 사이드바 확인용 (더기)  */}
             <Route path=":id" element={<BookClubLayout />}>
               <Route path="home" element={<BookClubHomePage />} />
-              <Route path="bookaddpage" element={<BookAddPage />} />
 
+              {/* 책장 */}
               <Route path="shelf" element={<ShelfHomePage />} />
               <Route path="shelf/:shelfBookIndex" element={<ShelfDetailPage />} />
               <Route path="shelf/:shelfBookIndex/theme" element={<ThemeDetailPage />} />
               <Route path="shelf/:shelfBookIndex/score" element={<ScoreDetailPage />} />  
+
+              {/* 책 추천 */}
+              <Route path="recommend/searchrecommendbook" element={<SearchRecommendBookPage />} />
             </Route>
           </Route>
           <Route path="/test-header" element={<TestHeaderPage />} />

--- a/src/components/ClubSideBar.tsx
+++ b/src/components/ClubSideBar.tsx
@@ -44,7 +44,7 @@ const ClubSideBar = () => {
       icon: homeIcon,
       submenus: [
         { name: "공지사항", path: `/bookclub/${id}/notice` },
-        { name: "책장", path: `/bookclub/${id}/bookcase` },
+        { name: "책장", path: `/bookclub/${id}/shelf` },
         { name: "모임", path: `/bookclub/${id}/meeting` },
         { name: "책 추천", path: `/bookclub/${id}/recommend` },
         { name: "일정", path: `/bookclub/${id}/schedule` },

--- a/src/pages/BookClub/Review/EditPage.tsx
+++ b/src/pages/BookClub/Review/EditPage.tsx
@@ -1,9 +1,0 @@
-
-
-const EditPage = () => {
-  return (
-    <div>EditPage</div>
-  )
-}
-
-export default EditPage

--- a/src/pages/BookClub/Review/HomePage.tsx
+++ b/src/pages/BookClub/Review/HomePage.tsx
@@ -1,9 +1,0 @@
-
-
-const HomePage = () => {
-  return (
-    <div>HomePage</div>
-  )
-}
-
-export default HomePage

--- a/src/pages/BookClub/Shelf/IssuePage.tsx
+++ b/src/pages/BookClub/Shelf/IssuePage.tsx
@@ -1,9 +1,0 @@
-
-
-const IssuePage = () => {
-  return (
-    <div>IssuePage</div>
-  )
-}
-
-export default IssuePage

--- a/src/pages/BookClub/Shelf/ScoreDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ScoreDetailPage.tsx
@@ -36,8 +36,28 @@ export default function ScoreDetailPage() {
   ])
 
   const [isAdding, setIsAdding] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
   const [newScore, setNewScore] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+    const ta = e.currentTarget;
+    ta.style.height = 'auto';               // 높이 리셋
+    ta.style.height = ta.scrollHeight + 'px'; // 내용에 맞게 늘리기
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const ta = e.currentTarget;
+      const start = ta.selectionStart;
+      const end = ta.selectionEnd;
+      // 탭 문자 삽입
+      ta.value = ta.value.slice(0, start) + '\t' + ta.value.slice(end);
+      // 커서 위치 복원
+      ta.selectionStart = ta.selectionEnd = start + 1;
+    }
+  };
+
 
   const handleSend = () => {
     const text = inputRef.current?.value.trim()
@@ -58,11 +78,6 @@ export default function ScoreDetailPage() {
 
   return (
     <div className="flex h-screen">
-      {/* 사이드바 자리*/}
-      <aside className="w-[264px] bg-[#F1F8EF] flex items-center justify-center">
-        <span>사이드바</span>
-      </aside>
-
       {/* 메인 */}
       <div className="absolute top-[30px] left-[305px] right-[34px] ">
 
@@ -88,23 +103,23 @@ export default function ScoreDetailPage() {
             <div className="flex flex-col gap-[12px]">
               
             {scores.map(item => (
-              <div key={item.id} className="flex bg-[#F4F2F1] shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] items-center">
-
-                {/* 프로필 + 닉네임 영역 */}
-                <div className="ml-[12px] flex gap-[19px] items-center w-[222px] flex-shrink-0 my-[10px] ">
-                  <img src= "/assets/ix_user-profile-filled.svg" className="w-12 h-12 rounded-full object-cover" />
-                  <span className="font-semibold text-[15px] text-gray-800 mb-1">{item.nickname}</span>
-                </div>
-
-                {/* 별점 영역 */}
-                <div className="flex items-center mr-[34px] flex-shrink-0">
-                  {[0,1,2,3,4].map(i => (
-                    <img key={i} src={getStarIcon(item.score, i)} className="w-5 h-5" />
-                  ))}
+              <div key={item.id} className="flex py-3 bg-[#F4F2F1] shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]">
+                <div className="flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]">
+                    <img src="/assets/ix_user-profile-filled.svg" className="w-[48px] h-[48px] rounded-full object-cover"/>
+                    <div className="flex-1 ml-[19px]  font-semibold text-[15px] text-gray-800">  {item.nickname} </div>
+                    
+                    <div className="flex justify-end items-center ">
+                        {[0, 1, 2, 3, 4].map((i) => (
+                          <img key={i} src={getStarIcon(item.score, i)} className="w-[20px] h-[20px]"
+                          />
+                          ))}
+                    </div>
                 </div>
                 
+
+                
                 {/* 한줄평 내용 영역 */}
-                <p className="font-pretendard text-sm font-medium leading-[145%] tracking-[-0.014px] text-[var(--Gray-1,#2C2C2C)] [font-feature-settings:'case' on] my-[20px] mr-[20px]">{item.comment}</p>
+                <p className="flex items-center font-pretendard text-sm font-medium leading-[145%] tracking-[-0.014px] text-[var(--Gray-1,#2C2C2C)] [font-feature-settings:'case' on] mr-[20px] whitespace-pre-wrap">{item.comment}</p>
                 
                 {/* 내 글인 경우 수정/삭제 버튼 영역 */}
                 {item.userid === currentUserId && (
@@ -122,27 +137,34 @@ export default function ScoreDetailPage() {
             
             {/* 한줄평 추가 영역 */}
             {isAdding && (
-              <div className=" flex shadow rounded-2xl bg-[#F4F2F1] border-2 border-[var(--sub-color-2-brown,#EAE5E2)] items-center w-full">
-                {/* 프로필 + 닉네임 영역 */}
-                <div className="ml-[12px] flex gap-[19px] items-center w-[222px] flex-shrink-0 my-[10px]">
-                  <img src="/assets/ix_user-profile-filled.svg" className="w-12 h-12 rounded-full" />
-                  <span className="font-semibold text-[15px] text-gray-800 mb-1">luke</span>
+              <div className="flex py-3 shadow rounded-2xl bg-[#F4F2F1] border-2 border-[var(--sub-color-2-brown,#EAE5E2)]  w-full">
+                {/* 프로필 + 닉네임 영역 + 별점선택 */}
+                <div className = "flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]">
+                  <img
+                      src="/assets/ix_user-profile-filled.svg"
+                      className="w-[48px] h-[48px] rounded-full object-cover"
+                      alt="내 프로필" />
+                  <div className="flex-1 ml-[19px]  font-semibold text-[15px] text-gray-800">luke</div>
+
+                  <div className="flex justify-end items-center">
+                    {[0,1,2,3,4].map(i => (
+                      <img key={i} src={getStarIcon(newScore, i)} className="w-[20px] h-[20px] cursor-pointer" onClick={() => {
+                        setNewScore(prev => prev === i+1 ? i + 0.5 : i + 1)
+                      }} />
+                    ))}
+                  </div>
                 </div>
 
-                {/* 별점 선택 영역 */}
-                <div className="flex items-center mr-[34px] flex-shrink-0">
-                  {[0,1,2,3,4].map(i => (
-                    <img key={i} src={getStarIcon(newScore, i)} className="w-5 h-5 cursor-pointer" onClick={() => {
-                      setNewScore(prev => prev === i+1 ? i + 0.5 : i + 1)
-                    }} />
-                  ))}
-                </div>
+
 
                 {/* 한줄평 입력 영역 */}
-                <div className="flex-1 border-b-2 border-[var(--sub-color-2-brown,#EAE5E2)] mr-[20px]">
-                  <input ref={inputRef} type="text" placeholder="한줄평을 입력해 주세요" className="w-full text-[14px] text-gray-700 leading-snug my-[10px] bg-transparent focus:outline-none" />
+                <div className="flex-1 mr-[20px] min-h-[48px] flex items-center ">
+                  <textarea ref={inputRef} type="text" rows={1} placeholder="한줄평을 입력해 주세요" onInput={handleInput}
+                    onKeyDown={handleKeyDown}
+                    className="flex items-center w-full text-[14px]  leading-snug bg-transparent focus:outline-none overflow-hidden resize-none min-h-[20px] py-2 border-b-2 border-[var(--sub-color-2-brown,#EAE5E2)]" />
                 </div>
-                <button onClick={handleSend} className="mr-[15px] hover:cursor-pointer">
+
+                <button onClick={handleSend} className="h-12 w-6 mr-[15px] hover:cursor-pointer">
                   <img src="/assets/등록.svg" className="w-6 h-6" />
                 </button>
               </div>

--- a/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
@@ -39,26 +39,25 @@ export interface ShelfBookScore {
 }
 export default function ShelfDetailPage() {
   const navigate = useNavigate();
-  const { prefix, bookId } = useParams<{ prefix: string; bookId: string }>()
-  console.log("prefix:", prefix);
-  console.log("bookId:", bookId);
+  const { BookClubID, bookId } = useParams<{ id: string; bookId: string }>()
+  console.log(BookClubID, bookId);
   // 책장 더미 데이터
   const dummyShelfBook = { id: '1124', title: '넥서스', term: 7, tag: '인문학', author: '유발 하라리', translator: '출판 장비', coverUrl: '/assets/covers/nexus.jpg', average_score: 4.3 }
-  const dummyRecommandment : String = '이 책은 인류의 미래와 AI의 역할에 대한 깊은 통찰을 제공합니다. 유발 하라리의 독창적인 시각으로, 인간과 AI의 공존 가능성을 탐구하며, 독자에게 새로운 관점을 제시합니다. 이 책을 통해 우리는 기술과 인간의 관계를 재조명할 수 있습니다.'
+  const dummyRecommandment : String = '이 책은 인류의 미래와 AI의 역할에 대한 깊은 통찰을 제공합니다. 유발 하라리의 독창적인 시각으로, 인간과 AI의 공존 가능성을 탐구하며, 독자에게 새로운 관점을 제시합니다. 이 책을 통해 우리는 기술과 인간의 관계를 재조명할 수 있습니다.이 책은 인류의 미래와 AI의 역할에 대한 깊은 통찰을 제공합니다. 유발 하라리의 독창적인 시각으로, 인간과 AI의 공존 가능성을 탐구하며, 독자에게 새로운 관점을 제시합니다. 이 책을 통해 우리는 기술과 인간의 관계를 재조명할 수 있습니다'
   const dummyShelfBookThemes: ShelfBookTheme[] = [
-  { id: '1124', profileUrl: '/assets/avatars/user1.png', nickname: 'alice', theme: 'AI와 인간의 공존에 대해 토론했어요.길이늘리기길이늘리기길이늘리기길이늘리기길이늘리기길이늘리기길이늘리기길이늘리기길이늘리기길이늘리기길이늘리기길이늘리리기길이늘리기길이늘리기길이늘리기길이늘리기길이늘리기' },
-  { id: '1242', profileUrl: '/assets/avatars/user2.png', nickname: 'bob', theme: '역사적 관점에서 본 미래 예측 세션.' },
-  { id: '3124', profileUrl: '/assets/avatars/user3.png', nickname: 'carol', theme: '비인간 지능의 윤리적 쟁점 리뷰.' },
-  { id: '441',  profileUrl: '/assets/avatars/user4.png', nickname: 'dave', theme: '책 속 사례를 활용한 워크숍 진행.' },
+  { id: '1124', profileUrl: '/assets/avatars/user1.png', nickname: 'alice', theme: 'AI와 인간의 공존에 대해 토론했어요.길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 ' },
+  { id: '1242', profileUrl: '/assets/avatars/user2.png', nickname: 'bob', theme: '역사적 관점에서 본 미래 예측 세션길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 .' },
+  { id: '3124', profileUrl: '/assets/avatars/user3.png', nickname: 'carol', theme: '비인간 지능의 윤리적 쟁점 리뷰.길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 ' },
+  { id: '441',  profileUrl: '/assets/avatars/user4.png', nickname: 'dave', theme: '책 속 사례를 활용한 워크숍 진행길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 .' },
   { id: '145',  profileUrl: '/assets/avatars/user5.png', nickname: 'eve', theme: '핵심 개념 요약과 퀴즈 세션.' },
   { id: '1246', profileUrl: '/assets/avatars/user6.png', nickname: 'frank', theme: '관련 논문 리뷰와 발표.' },
   { id: '1247', profileUrl: '/assets/avatars/user7.png', nickname: 'grace', theme: '심화 질문을 나누는 자유 토론.' },
   ]
   const dummyShelfBookScores: ShelfBookScore[] = [
   { id: '1124', profileUrl: '/assets/avatars/user1.png', nickname: 'alice', score: 4.5, comment: '정말 흥미롭고 유익했어요!' },
-  { id: '1242', profileUrl: '/assets/avatars/user2.png', nickname: 'bob',   score: 3.0, comment: '조금 어려웠지만 배울 점이 많았습니다.' },
-  { id: '3124', profileUrl: '/assets/avatars/user3.png', nickname: 'carol', score: 5.0, comment: '최고의 독서 경험이었어요!' },
-  { id: '441',  profileUrl: '/assets/avatars/user4.png', nickname: 'dave',  score: 4.0, comment: '핵심 포인트가 잘 정리되어 있어 좋았습니다.' },
+  { id: '1242', profileUrl: '/assets/avatars/user2.png', nickname: 'bob',   score: 3.0, comment: '조금 어려웠지만 배울 점이 많았습니다.길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 ' },
+  { id: '3124', profileUrl: '/assets/avatars/user3.png', nickname: 'carol', score: 5.0, comment: '최고의 독서 경험이었어요!길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 ' },
+  { id: '441',  profileUrl: '/assets/avatars/user4.png', nickname: 'dave',  score: 4.0, comment: '핵심 포인트가 잘 정리되어 있어 좋았습니다.길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 길이늘리기 ' },
   { id: '145',  profileUrl: '/assets/avatars/user5.png', nickname: 'eve',   score: 2.5, comment: '좀 더 사례가 필요했어요.' },
   { id: '1246', profileUrl: '/assets/avatars/user6.png', nickname: 'frank', score: 3.5, comment: '전체적으로 균형 잡힌 내용입니다.' },
   { id: '1247', profileUrl: '/assets/avatars/user7.png', nickname: 'grace', score: 4.0, comment: '다양한 시각을 접할 수 있어 좋았어요.' },
@@ -71,14 +70,34 @@ export default function ShelfDetailPage() {
   // 나중에 리팩토링해서 별점관리 따로 할 것!
   const [newRating, setNewRating] = useState<number>(0)
 
-
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  
+    const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+        const ta = e.currentTarget;
+        ta.style.height = 'auto';               // 높이 리셋
+        ta.style.height = ta.scrollHeight + 'px'; // 내용에 맞게 늘리기
+      };
+    
+      const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === 'Tab') {
+          e.preventDefault();
+          const ta = e.currentTarget;
+          const start = ta.selectionStart;
+          const end = ta.selectionEnd;
+          // 탭 문자 삽입
+          ta.value = ta.value.slice(0, start) + '\t' + ta.value.slice(end);
+          // 커서 위치 복원
+          ta.selectionStart = ta.selectionEnd = start + 1;
+        }
+      };
+      
+      function handleSend() {
+          // 리팩토링 후 API연결할 것 
+      }
+    
 
   return (
     <div className="flex h-screen">
-      {/* 사이드바 자리*/}
-      <div className="w-[264px] bg-[#F1F8EF] flex flex-col items-center justify-center gap-[45px] opacity-100">
-          <span>사이드바 자리</span>
-      </div>
       {/* 메인 */}
       <div className="absolute top-[30px] left-[305px] right-[34px] ">
 
@@ -136,15 +155,14 @@ export default function ShelfDetailPage() {
             {/* 발제 리스트 */}
             <div className="flex flex-col gap-[22px] ">
               {randomThemes.map((theme) => (
-                <div key={theme.id} className="flex  shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] items-center">
-                  <div className= "ml-[12px] flex gap-[19px] items-center w-[222px] flex-shrink-0 my-[10px] " >
+                <div key={theme.id} className="py-3 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]">
+                  <div className= "flex h-[48px] ml-[12px] gap-[19px] items-center w-[222px] flex-shrink-0" >
                     <img src= "/assets/ix_user-profile-filled.svg" className="w-[48px] h-[48px] rounded-full object-cover" />
-                    <div className="font-semibold text-[15px] text-gray-800 mb-1">{theme.nickname}</div>
+                    <div className="font-semibold text-[15px] text-gray-800">{theme.nickname}</div>
                   </div>
                   
-                  <div>
-                    <div className="font-pretendard text-sm font-medium leading-[145%] tracking-[-0.014px] text-[var(--Gray-1,#2C2C2C)] [font-feature-settings:'case' on] my-[20px] mr-[20px]">{theme.theme}</div>
-                  </div>
+                  <div className="flex items-center font-pretendard text-sm font-medium leading-[145%] tracking-[-0.014px] text-[var(--Gray-1,#2C2C2C)] [font-feature-settings:'case' on] mr-[20px] whitespace-pre-wrap">{theme.theme}</div>
+
                 </div>
               ))}
             </div>
@@ -158,75 +176,76 @@ export default function ShelfDetailPage() {
 
           </div>
 
-          {/* 한줄평 3개 */}
+          {/* 한줄평*/}
           <div className="mt-[64px] flex flex-col mb-[73px]">
             <span className="mb-[22px] text-[18px] font-[Pretendard] font-medium leading-[135%] text-black">한줄평</span>
 
             {/* 한줄평 리스트 */}
             <div className="flex flex-col gap-[22px]">
               {randomScores.map((score) => (
-                <div key={score.id}  className="flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] items-center">
-                  <div className="ml-[12px] flex gap-[19px] items-center w-[222px] flex-shrink-0 my-[10px]">
+                <div key={score.id}  className="flex py-3 shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]">
 
-                    <img src="/assets/ix_user-profile-filled.svg" className="w-[48px] h-[48px] rounded-full object-cover"/>
-                    <div className="font-semibold text-[15px] text-gray-800 mb-1">  {score.nickname} </div>
+                      <div className="flex items-center justify-between h-[48px] w-[270px] flex-none] ml-[12px] mr-[34px]">
 
-                  </div>
-                  <div className="flex-1 flex">
-                    <div className="flex items-center">
-                      {/* 별점 */}
-                      {[0, 1, 2, 3, 4].map((i) => (
-                        <img key={i} src={getStarIcon(score.score, i)} className="w-[16px] h-[16px]"
-                        />
-                      ))}
+                        <img src="/assets/ix_user-profile-filled.svg" className="w-[48px] h-[48px] rounded-full object-cover"/>
+
+                        <div className="flex-1 ml-[19px]  font-semibold text-[15px] text-gray-800">  {score.nickname} </div>
+
+                        <div className="flex justify-end items-center ">
+                        {[0, 1, 2, 3, 4].map((i) => (
+                          <img key={i} src={getStarIcon(score.score, i)} className="w-[20px] h-[20px]"
+                          />
+                          ))}
+                      </div>
+                      
+
                     </div>
-                    <div className="text-[14px] text-gray-700 leading-snug break-words my-[20px] ml-[15px] mr-[20px]">
+
+                    <div className="flex-1 flex items-center font-pretendard text-sm font-medium leading-[145%] tracking-[-0.014px]  break-words mr-[20px] whitespace-pre-wrap">
                       {score.comment}
                     </div>
-                  </div>
+
                 </div>
               ))}
             </div>
             
-            <div className="mt-[22px] flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] items-center">
-              {/* 1) 프로필 + 닉네임 */}
-              <div className="ml-[12px] flex gap-[19px] items-center w-[222px] flex-shrink-0 my-[10px]">
-                <img
-                  src="/assets/ix_user-profile-filled.svg"
-                  className="w-[48px] h-[48px] rounded-full object-cover"
-                  alt="내 프로필"
-                />
-                <div className="font-semibold text-[15px] text-gray-800 mb-1">
-                  luke
-                </div>
-              </div>
-              {/* 2) 별점 영역 클릭 1개 / 한번 더 클릭 반개*/}
-              <div className="flex items-center mr-[15px]">
-                {[0, 1, 2, 3, 4].map((i) => (
-                  <img
-                    key={i}
-                    src={getStarIcon(newRating, i)}
-                    className="w-[16px] h-[16px] cursor-pointer"
-                    onClick={() => {
-                      setNewRating(prev => prev === i+1 ? i + 0.5 : i + 1)
-                    }}
+            <div className="mt-[22px] flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] py-[8px]">
+              <div className = "flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]">
+                {/* 1) 프로필 + 닉네임 */}
+                    <img
+                    src="/assets/ix_user-profile-filled.svg"
+                    className="w-[48px] h-[48px] rounded-full object-cover"
+                    alt="내 프로필"
                   />
-                ))}
+                  <div className="flex-1 ml-[19px]  font-semibold text-[15px] text-gray-800">
+                    luke
+                  </div>
+
+                {/* 2) 별점 영역 클릭 1개 / 한번 더 클릭 반개*/}
+                <div className="flex justify-end items-center">
+                  {[0, 1, 2, 3, 4].map((i) => (
+                    <img
+                      key={i}
+                      src={getStarIcon(newRating, i)}
+                      className="w-[20px] h-[20px] cursor-pointer"
+                      onClick={() => {
+                        setNewRating(prev => prev === i+1 ? i + 0.5 : i + 1)
+                      }}
+                    />
+                  ))}
+                </div>  
               </div>
 
-              {/* 3) 입력창 */}
-              <div className="flex-1 border-b-2 border-[var(--sub-color-2-brown,#EAE5E2)] mr-">
-                <input type="text"  placeholder="한줄평을 입력해 주세요"  className="w-full text-[14px] text-gray-700 leading-snug break-words my-[10px]  mr-[20px] bg-transparent focus:outline-none" />
-              </div>
+              {/* 한줄평 입력 영역 */}
+                <div className="flex-1 mr-[20px] min-h-[48px] flex items-center ">
+                  <textarea ref={inputRef} type="text" rows={1} placeholder="한줄평을 입력해 주세요" onInput={handleInput}
+                    onKeyDown={handleKeyDown}
+                    className="flex items-center w-full text-[14px]  leading-snug bg-transparent focus:outline-none overflow-hidden resize-none min-h-[20px] py-2 border-b-2 border-[var(--sub-color-2-brown,#EAE5E2)]" />
+                </div>
 
-              {/* 4) 전송 버튼 */}
-              <button className="mr-[15px] hover:cursor-pointer">
-                <img
-                  src="/assets/등록.svg"
-                  className="w-[24px] h-[24px]"
-                  alt="전송"
-                />
-              </button>
+                <button onClick={handleSend} className="h-12 w-6 mr-[15px] hover:cursor-pointer">
+                  <img src="/assets/등록.svg" className="w-6 h-6" />
+                </button>
             </div>
 
             {/* +더보기 버튼 */}

--- a/src/pages/BookClub/Shelf/ShelfHomePage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfHomePage.tsx
@@ -15,7 +15,8 @@ export interface ShelfBook {
 }
 
 export default function ShelfHomePage() {
-  const { prefix } = useParams<{ prefix: string }>();
+  const { BookClubID } = useParams<{ id: string }>();
+  console.log(BookClubID)
   const [maxTerm, setMaxTerm] = useState(7)  // 초깃값 7기
   const [Term,setTerm] = useState(0) 
   const [shelfBooks, setShelfBooks] = useState<ShelfBook[]>([])
@@ -27,7 +28,7 @@ export default function ShelfHomePage() {
   { id: '1124', title: '넥서스', term: 7, tag: '인문학', author: '유발 하라리', coverUrl: '/assets/covers/nexus.jpg', average_score: 4.3 },
   { id: '1242', title: '사피엔스', term: 5, tag: '역사', author: '유발 하라리', translator: '홍길동', coverUrl: '/assets/covers/sapiens.jpg', average_score: 3.1 },
   { id: '3124', title: '호모 데우스', term: 6, tag: '미래학', author: '유발 하라리', translator: '김철수', coverUrl: '/assets/covers/homo-deus.jpg', average_score: 4.8 },
-  { id: '441', title: '21세기를 위한 21가지 제언', term: 7, tag: '사회과학', author: '유발 하라리', coverUrl: '/assets/covers/21-lessons.jpg', average_score: 4.5 },
+  { id: '441', title: '21세기를 위한 21가지 제언1111111111', term: 7, tag: '사회과학', author: '유발 하라리', coverUrl: '/assets/covers/21-lessons.jpg', average_score: 4.5 },
   { id: '145', title: '총, 균, 쇠', term: 4, tag: '역사', author: '재러드 다이아몬드', translator: '이재성', coverUrl: '/assets/covers/guns-germs-steel.jpg', average_score: 4.0 },
   { id: '1246', title: '블러드라인', term: 3, tag: '가족사', author: '타워 바제스', translator: '박지연', coverUrl: '/assets/covers/bloodline.jpg', average_score: 3.7 },
   { id: '1247', title: '파친코', term: 2, tag: '소설', author: '이민진', coverUrl: '/assets/covers/pachinko.jpg', average_score: 4.2 },
@@ -57,22 +58,20 @@ export default function ShelfHomePage() {
 
   return (
     <div className="flex h-screen">
-      {/* 사이드바 자리*/}
-      <div className="w-[264px] bg-[#F1F8EF] flex flex-col items-center justify-center gap-[45px] opacity-100">
-          <span>사이드바 자리</span>
-      </div>
       {/* 메인 컨텐츠 자리 */}
-      <div className="absolute top-[30px] left-[305px] right-[34px]">
+      <div className="absolute left-[302px] right-[34px]">
         {/* 헤더 자리 */}
-        <Header pageTitle={'title'} userProfile={{
-          username: '123',
-          bio: '123'
-        }} notifications={[]}/>
+        <Header pageTitle={'책장'} userProfile={{
+          username: 'Luke',
+          bio: '아 피곤하다.'
+        }} 
+        notifications={[]}
+        customClassName="mt-[30px]"
+        />
   
-        <div className="mt-10 flex flex-col gap-[18px]">
+        <div className="mt-[54px] flex flex-col gap-[18px]">
           {/* 타이틀과 기수 */}
           <div className="flex items-center justify-between w-full h-[24px]">
-
             <h1 className="font-[Pretendard] font-medium text-[18px] leading-[135%]">독서 목록</h1>
 
             <div className="relative w-[72px] mr-[24px]">
@@ -105,57 +104,57 @@ export default function ShelfHomePage() {
           {/* 책장 리스트 */}
           <div className="grid grid-cols-3 gap-x-[12px] gap-y-[24px] overflow-y-auto h-[calc(100vh-171px)] overscroll-none "  style={{ msOverflowStyle: 'none', scrollbarWidth: 'none' }}>
             {shelfBooks.map((ShelfBook, idx) => (
-          <Link key={idx}  to={`/${prefix}/shelf/${ShelfBook.id}`}  className="block">
-            <div className="flex h-[240px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] hover:shadow-lg transition-shadow">
+          <Link key={idx}  to={`${location.pathname}/${ShelfBook.id}`}  className="flex min-w-90 h-[260px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] hover:shadow-lg transition-shadow block">
 
-            {/* 왼쪽 */}
-            <div className="w-[156px] flex-shrink-0 h-full rounded-2xl overflow-hidden bg-gray-200">
-              <img
-                src={ShelfBook.coverUrl}
-                alt={ShelfBook  .title}
-                className="w-full h-full object-cover"
-              />
-            </div>
+  
+              {/* 왼쪽 */}
+              <div className="w-[156px] flex-shrink-0 h-full rounded-2xl overflow-hidden bg-gray-200">
+                <img
+                  src={ShelfBook.coverUrl}
+                  alt={ShelfBook  .title}
+                  className="w-full h-full object-cover"
+                />
+              </div>
 
             {/* 오른쪽: 남은 공간을 모두 차지 */}
-            <div className="flex-1 h-full flex flex-col">
+            <div className="flex flex-col h-full flex-1 min-h-0 overflow-hidden">
 
               {/* 1) 제목 */}
-              <p className="text-[14px] font-[Pretendard] font-semibold  leading-[135%] text-[var(--Gray1,#2C2C2C)]">
+              <p className="flex-1 min-w-0 flex-none h-[17px] text-[14px] font-[Pretendard] font-semibold  leading-[135%] text-[var(--Gray1,#2C2C2C)] truncate ">
                 {ShelfBook.title}
               </p>
               {/* 2) 저자 · 번역자 */}
-              <p className="text-[12px] text-[#8D8D8D] font-[Pretendard] font-medium leading-[145%] ">
+              <p className="flex-1 min-w-0 flex-none h-[17px] text-[12px] text-[#8D8D8D] font-[Pretendard] font-medium leading-[145%] truncate ">
                 {ShelfBook.author} 지음
                 {ShelfBook.translator && ` | ${ShelfBook.translator} 옮김`}
               </p>
-              {/* 3) term·tag pills (10px 아래 여백) */}
-              <div className="mt-[10px] flex gap-[8px] ">
-                <span className="px-[20px] py-[2px] text-[12px] rounded-full bg-[#90D26D] text-white">
+              {/* 3) term, tag  (10px 아래 여백) */}
+              <div className="flex mt-[10px] gap-2 ">
+                <p className="flex-shrink-0 h-6 w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-[12px]  text-white">
                   {ShelfBook.term}기
-                </span>
-                <span className="px-[20px] py-[2px] text-[12px] rounded-full bg-[#90D26D] text-white">
+                </p>
+                <p className="flex-shrink-0 h-6 w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-[12px]  text-white">
                   {ShelfBook.tag}
-                </span>
+                </p>
               </div>
 
             {/* 4–6) 링크 3개 (20px 아래 여백, 링크별 색상 예시) */}
-            <div className="mt-[24px] flex flex-col items-center">
-          <Link to={`/${prefix}/shelf/${ShelfBook.id}/theme`}className="block">
+            <div className="mt-[24px] flex flex-col">
+          <Link to={`${location.pathname}/${ShelfBook.id}/theme`}className="block">
             <div className=" w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between">
               <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C] items-center">
                 발제</span>
               <img src="/assets/바로가기.svg" className="w-[24px] h-[24px]"/>
             </div>
           </Link>
-          <Link to={`/${prefix}/shelf/${ShelfBook.id}/score`}className="block">
+          <Link to={`${location.pathname}/${ShelfBook.id}/score`}className="block">
             <div className=" w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between">
               <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C] items-center">
                 한줄평</span>
               <img src="/assets/바로가기.svg" className="w-[24px] h-[24px]"/>
             </div>
           </Link>
-          <Link to={`/${prefix}/shelf/${ShelfBook.id}/afterread`}className="block">
+          <Link to={`${location.pathname}/${ShelfBook.id}/afterread`}className="block">
             <div className=" w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between">
               <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C] items-center">
                 독서 후 활동</span>
@@ -174,7 +173,7 @@ export default function ShelfHomePage() {
               })}
             </div>
           </div>
-        </div>
+
       </Link>
       ))}
           </div>

--- a/src/pages/BookClub/Shelf/ThemeDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ThemeDetailPage.tsx
@@ -27,6 +27,28 @@ export default function ThemeDetailPage() {
 
   const [isAdding, setIsAdding] = useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+      const ta = e.currentTarget;
+      ta.style.height = 'auto';               // 높이 리셋
+      ta.style.height = ta.scrollHeight + 'px'; // 내용에 맞게 늘리기
+    };
+  
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const ta = e.currentTarget;
+        const start = ta.selectionStart;
+        const end = ta.selectionEnd;
+        // 탭 문자 삽입
+        ta.value = ta.value.slice(0, start) + '\t' + ta.value.slice(end);
+        // 커서 위치 복원
+        ta.selectionStart = ta.selectionEnd = start + 1;
+      }
+    };
+  
+
+
   const myId = '1004' //임시로 내 ID 설정
 
   function handleSend() {
@@ -50,10 +72,6 @@ export default function ThemeDetailPage() {
 
   return (
     <div className="flex h-screen">
-      {/* 사이드바 자리*/}
-      <div className="w-[264px] bg-[#F1F8EF] flex flex-col items-center justify-center gap-[45px] opacity-100">
-          <span>사이드바 자리</span>
-      </div>
       {/* 메인 */}
       <div className="absolute top-[30px] left-[305px] right-[34px] ">
 
@@ -81,14 +99,14 @@ export default function ThemeDetailPage() {
               {/* 발제 리스트 */}
               <div className="flex flex-col gap-[12px]">
                 {dummyShelfBookThemes.map(theme => (
-                  <div key={theme.id} className="flex bg-[#F4F2F1] shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] items-center">
-                    <div className= "ml-[12px] flex gap-[19px] items-center w-[222px] flex-shrink-0 my-[10px] " >
+                  <div key={theme.id} className=" py-3 flex bg-[#F4F2F1] shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]">
+                    <div className= "flex-shrink-0 items-center w-[222px] h-[48px] ml-[12px] flex gap-[19px] mr-[15px] " >
                       <img src= "/assets/ix_user-profile-filled.svg" className="w-[48px] h-[48px] rounded-full object-cover" />
                       <div className="font-semibold text-[15px] text-gray-800 mb-1">{theme.nickname}</div>
                     </div>
                     
                     {/* 발제 내용 */}
-                    <p className="font-pretendard text-sm font-medium leading-[145%] tracking-[-0.014px] text-[var(--Gray-1,#2C2C2C)] [font-feature-settings:'case' on] my-[20px] mr-[20px]">{theme.theme}</p>
+                    <p className="flex items-center font-pretendard text-sm font-medium leading-[145%] tracking-[-0.014px] text-[var(--Gray-1,#2C2C2C)] [font-feature-settings:'case' on] mr-[20px]  whitespace-pre-wrap">{theme.theme}</p>
                     
                     {/* 내 글인 경우 글쓰기/삭제 버튼 */}
                       {theme.userid === myId && (
@@ -107,19 +125,20 @@ export default function ThemeDetailPage() {
 
               {/* 발제 추가 영역 */}
               {isAdding && (
-              <div className="mt-[11px] flex shadow rounded-2xl bg-[#F4F2F1] border-2 border-[var(--sub-color-2-brown,#EAE5E2)] items-center w-full">
+              <div className="mt-[11px] flex shadow rounded-2xl bg-[#F4F2F1] border-2 border-[var(--sub-color-2-brown,#EAE5E2)]  w-full">
                 {/* 1) 프로필 + 닉네임 */}
-                <div className="ml-[12px] flex gap-[19px] items-center w-[222px] flex-shrink-0 my-[10px]">
+                <div className=" ml-[12px] flex gap-[19px] items-center h-12 w-[222px] flex-shrink-0 my-[10px] mr-[15px]">
                   <img src="/assets/ix_user-profile-filled.svg" className="w-[48px] h-[48px] rounded-full object-cover" alt="내 프로필" />
                   <div className="font-semibold text-[15px] text-gray-800 mb-1">luke</div>
                 </div>
                 {/* 2) 입력창 */}
-                <div className="flex-1 border-b-2 border-[var(--sub-color-2-brown,#EAE5E2)] mr-[20px]">
-                  <input  type="text" placeholder="발제를 입력해 주세요" ref={inputRef} className="w-full text-[14px] text-gray-700 leading-snug my-[10px] bg-transparent focus:outline-none"
-                  />
+                <div className="flex-1 mr-[20px] min-h-[48px] flex items-center ">
+                  <textarea ref={inputRef} type="text" rows={1} placeholder="한줄평을 입력해 주세요" onInput={handleInput}
+                    onKeyDown={handleKeyDown}
+                    className="flex items-center w-full text-[14px]  leading-snug bg-transparent focus:outline-none overflow-hidden resize-none min-h-[20px] py-2 border-b-2 border-[var(--sub-color-2-brown,#EAE5E2)]" />
                 </div>
                 {/* 3) 전송 버튼 */}
-                <button onClick={handleSend} className="mr-[15px] hover:cursor-pointer">
+                <button onClick={handleSend} className="mt-5 w-[24px] h-[24px] mr-[15px] hover:cursor-pointer">
                   <img src="/assets/등록.svg" className="w-[24px] h-[24px]" alt="전송" />
                 </button>
               </div>

--- a/src/pages/BookRecommend/SearchRecommendBookPage.tsx
+++ b/src/pages/BookRecommend/SearchRecommendBookPage.tsx
@@ -1,11 +1,11 @@
-//BookAddPage.tsx
+//SearchRecommendBookPage.tsx
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-import BookSearch, { type Book, type Action } from '../../../components/Search/BookSearch'
+import BookSearch, { type Book, type Action } from '../../components/Search/BookSearch'
 import { useParams } from 'react-router-dom'
-import Header from '../../../components/Header'
+import Header from '../../components/Header'
 
-export default function BookAddPage() {
+export default function SearchRecommendBookPage() {
   const navigate = useNavigate()
    const { id } = useParams<{ id: string }>()
 


### PR DESCRIPTION
Shelf페이지 UI 세부사항 완성
1. 제목과 저자가 박스를 넘어갈 시 ...으로 표기
2. 한줄평, 발제 등록 시 다수의 줄로 적을 수 있도록 + 줄이 길어지면 박스가 자연스럽게 늘어나도록
3. 긴 텍스트여도 상단에 이름이 고정
4. 별위치 수정

등등의 UI design들

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 북클럽 내에서 추천 도서 검색 페이지가 추가되었습니다.

* **버그 수정**
  * '책장' 서브메뉴 경로가 `/bookcase`에서 `/shelf`로 변경되었습니다.

* **UI/스타일 개선**
  * 책장 상세, 한줄평, 테마 상세 페이지에서 댓글 및 입력란이 멀티라인, 자동 높이 조절, 탭 입력 지원 등으로 개선되었습니다.
  * 레이아웃과 스타일이 일관성 있게 다듬어졌으며, 일부 불필요한 사이드바가 제거되었습니다.

* **기타**
  * 사용되지 않는 단순 테스트용 페이지(예: EditPage, HomePage, IssuePage)가 삭제되었습니다.
  * 일부 내부 경로 및 컴포넌트 명칭이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->