### PR TITLE
[feat] 독서모임 검색하기 카테고리 태그 재구현 및 api 관련 수정

### DIFF
--- a/src/apis/clubApi.ts
+++ b/src/apis/clubApi.ts
@@ -1,0 +1,31 @@
+import axiosInstance from "../lib/axiosInstance";
+import type { ClubDto } from "../types/dto";
+
+// 클럽 목록 조회
+export const getClubList = async (): Promise<ClubDto[]> =>
+  axiosInstance
+    .get<ClubDto[]>('/api/clubs')
+    .then((r) => r.data);
+
+// 클럽 생성
+export const createClub = async (clubData: Omit<ClubDto, 'clubId'>): Promise<{isSuccess: boolean, code: string, message: string, result: ClubDto}> => {
+  const headers = {
+    'MemberId': 'mem_001' // 임시로 고정값 사용, 나중에 시큐리티 구현 후 삭제
+  };
+  
+  return axiosInstance
+    .post<{isSuccess: boolean, code: string, message: string, result: ClubDto}>('/api/clubs', clubData, { headers })
+    .then((r) => r.data);
+};
+
+// 클럽 상세 조회
+export const getClubDetail = async (clubId: number): Promise<ClubDto> =>
+  axiosInstance
+    .get<ClubDto>(`/api/clubs/${clubId}`)
+    .then((r) => r.data);
+
+// 클럽 검색
+export const searchClubs = async (query: string): Promise<ClubDto[]> =>
+  axiosInstance
+    .get<ClubDto[]>(`/api/clubs/search?q=${encodeURIComponent(query)}`)
+    .then((r) => r.data); 

--- a/src/components/SearchClub/ClubCard.tsx
+++ b/src/components/SearchClub/ClubCard.tsx
@@ -60,9 +60,10 @@ export default function ClubCard({
                   justify-center
                   text-[12px] font-medium
                   bg-[#90D26D] text-white
-                  w-[54px] h-[24px]
+                  px-[12px] h-[24px]
                   rounded-[15px]
                   whitespace-nowrap
+                  min-w-[54px]
                 "
               >
                 {categoryName}
@@ -168,33 +169,38 @@ export default function ClubCard({
                 </button>
               </div>
               <div className="absolute left-[213px] top-[196px] flex flex-col gap-[8px]">
-                <textarea
-                  placeholder="가입 메시지 작성"
-                  className="
-                    w-[699px] h-[40px] border-[2px] border-[#EAE5E2]
-                    rounded-[16px] px-[20px] py-[20px]
-                    font-pretendard font-medium text-[14px]
-                    leading-[145%] tracking-[-0.1%] text-[#2C2C2C]
-                    outline-none resize-none
-                  "
-                />
+                <div className="
+                  w-[684px] h-[180px] border-[2px] border-[#EAE5E2]
+                  rounded-[16px] px-[20px] py-[20px]
+                  relative
+                ">
+                  <textarea
+                    placeholder="가입 메시지 작성"
+                    className="
+                      w-full h-[120px] border-none
+                      font-pretendard font-medium text-[14px]
+                      leading-[145%] tracking-[-0.1%] text-[#2C2C2C]
+                      outline-none resize-none bg-transparent
+                    "
+                  />
+                  <div className="absolute bottom-[20px] right-[20px]">
+                    <button
+                      onClick={() => {}}
+                      className="
+                        w-[90px] h-[35px]
+                        bg-[#A6917D] text-white rounded-[16px] text-[12px]
+                        flex items-center justify-center
+                        cursor-pointer
+                      "
+                    >
+                      가입 신청하기
+                    </button>
+                  </div>
+                </div>
               </div>
             </>
           )}
-          {mode === 'join' && (
-            <button
-              onClick={() => {}}
-              className="
-                absolute left-[787px] top-[321px]
-                w-[90px] h-[35px]
-                bg-[#A6917D] text-white rounded-[16px] text-[12px]
-                flex items-center justify-center
-                cursor-pointer
-              "
-            >
-              가입 신청하기
-            </button>
-          )}
+
 
           {/* 문의 모드 */}
           {mode === 'inquiry' && (

--- a/src/components/SearchClub/ClubCard.tsx
+++ b/src/components/SearchClub/ClubCard.tsx
@@ -1,14 +1,15 @@
 // src/components/BookClub/ClubCard.tsx
 import React, { useState } from 'react';
 import checker from '../../assets/images/checker.png';
+import { BOOK_CATEGORIES, PARTICIPANT_TYPES } from '../../types/dto';
 
 export interface ClubCardProps {
   id: number;
   title: string;
-  /** 독서 카테고리 태그, ex: ['7기', '사회'] */
-  tags: string[];
-  /** 모임 대상, ex: '대학생' */
-  target: string;
+  /** 카테고리 ID 배열, ex: [1, 2, 3] */
+  category: number[];
+  /** 참여자 유형 배열, ex: ['STUDENT', 'WORKER'] */
+  participantTypes: string[];
   /** 활동 지역, ex: '서울' */
   region: string;
   /** 동아리 썸네일 URL */
@@ -17,12 +18,18 @@ export interface ClubCardProps {
 
 export default function ClubCard({
   title,
-  tags,
-  target,
+  category,
+  participantTypes,
   region,
   logoUrl,
 }: ClubCardProps): React.ReactElement {
   const [mode, setMode] = useState<'default' | 'join' | 'inquiry'>('default');
+
+  // 카테고리 ID를 이름으로 변환
+  const categoryNames = category.map(id => BOOK_CATEGORIES[id as keyof typeof BOOK_CATEGORIES] || `카테고리${id}`);
+  
+  // 참여자 유형을 이름으로 변환
+  const participantNames = participantTypes.map(type => PARTICIPANT_TYPES[type as keyof typeof PARTICIPANT_TYPES] || type);
 
   return (
     <div
@@ -43,10 +50,10 @@ export default function ClubCard({
         {/* 정보 영역 */}
         <div className="ml-[29px] flex-1 flex flex-col">
           {/* 카테고리 태그 */}
-          <div className="flex gap-[12px] mt-[24px] mb-[18px]">
-            {tags.map((t) => (
+          <div className="flex gap-[12px] mt-[24px] mb-[18px] flex-wrap">
+            {categoryNames.map((categoryName) => (
               <span
-                key={t}
+                key={categoryName}
                 className="
                   inline-flex
                   items-center
@@ -58,7 +65,7 @@ export default function ClubCard({
                   whitespace-nowrap
                 "
               >
-                {t}
+                {categoryName}
               </span>
             ))}
           </div>
@@ -81,7 +88,7 @@ export default function ClubCard({
               leading-[145%] tracking-[-0.1%] text-[#8D8D8D]
             "
           >
-            모임 대상 | {target}
+            모임 대상 | {participantNames.join(', ')}
           </p>
           <p
             className="

--- a/src/pages/Main/ClubSearchPage.tsx
+++ b/src/pages/Main/ClubSearchPage.tsx
@@ -10,20 +10,69 @@ export default function ClubSearchPage(): React.ReactElement {
 
   // 예시 더미 데이터
   const dummyClubs: ClubCardProps[] = [
-    { id: 1, title: '모임 명', tags: ['7기','사회'], target: '대학생', region: '서울', logoUrl: checker },
-    { id: 2, title: '모임 명', tags: ['7기','사회'], target: '대학생', region: '서울', logoUrl: checker },
-    { id: 3, title: '모임 명', tags: ['7기','사회'], target: '대학생', region: '서울', logoUrl: checker },
-    { id: 4, title: '모임 명', tags: ['7기','사회'], target: '대학생', region: '서울', logoUrl: checker },
-    { id: 5, title: '모임 명', tags: ['7기','사회'], target: '대학생', region: '서울', logoUrl: checker },
-    { id: 6, title: '모임 명', tags: ['7기','사회'], target: '대학생', region: '서울', logoUrl: checker },
-    { id: 7, title: '모임 명', tags: ['7기','사회'], target: '대학생', region: '서울', logoUrl: checker },
+    { 
+      id: 1, 
+      title: '북적북적 독서모임', 
+      category: [6], // 인문학
+      participantTypes: ['STUDENT'], 
+      region: '서울', 
+      logoUrl: checker 
+    },
+    { 
+      id: 2, 
+      title: '책을모아', 
+      category: [9, 10], // 사회과학, 정치/외교/국방
+      participantTypes: ['WORKER'], 
+      region: '부산', 
+      logoUrl: checker 
+    },
+    { 
+      id: 3, 
+      title: '슬기로운 독서생활', 
+      category: [2, 3, 7], // 소설/시/희곡, 에세이, 여행
+      participantTypes: ['STUDENT'], 
+      region: '대구', 
+      logoUrl: checker 
+    },
+    { 
+      id: 4, 
+      title: '독서재량', 
+      category: [4, 5], // 경제/경영, 자기계발
+      participantTypes: ['WORKER'], 
+      region: '서울', 
+      logoUrl: checker 
+    },
+    { 
+      id: 5, 
+      title: '책사랑', 
+      category: [8], // 역사/문화
+      participantTypes: ['STUDENT'], 
+      region: '인천', 
+      logoUrl: checker 
+    },
+    { 
+      id: 6, 
+      title: '독서모임', 
+      category: [11, 12], // 컴퓨터/IT, 과학
+      participantTypes: ['STUDENT'], 
+      region: '서울', 
+      logoUrl: checker 
+    },
+    { 
+      id: 7, 
+      title: '책읽는 사람들', 
+      category: [13, 14], // 외국어, 예술/대중문화
+      participantTypes: ['WORKER'], 
+      region: '광주', 
+      logoUrl: checker 
+    },
   ];
 
   // 검색 로직(예시)
   const filtered = dummyClubs.filter(c =>
     c.title.includes(query) ||
     c.region.includes(query) ||
-    c.target.includes(query)
+    c.participantTypes.some(type => type.includes(query))
   );
 
   return (
@@ -31,7 +80,7 @@ export default function ClubSearchPage(): React.ReactElement {
     <div className="absolute left-[315px] right-[42px] opacity-100">
       <Header pageTitle={'모임 검색하기'} userProfile={{
           username: 'dayoun',
-          bio: '아 피곤하다.'
+          bio: '아 피곤하다..'
         }} 
         notifications={[]}
         customClassName="mt-[60px]"

--- a/src/pages/Main/CreateClubPage.tsx
+++ b/src/pages/Main/CreateClubPage.tsx
@@ -1,22 +1,98 @@
 // src/pages/BookClub/CreateClubPage.tsx
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { ChipToggleGroup } from '../../components/CreateClub/ChipToggleGroup';
+import { createClub } from '../../apis/clubApi';
+import type { ClubDto } from '../../types/dto';
+import { BOOK_CATEGORIES, PARTICIPANT_TYPES } from '../../types/dto';
 
-const BOOK_CATEGORIES = [
-  '국내 도서','소설/시/희곡','에세이','경제/경영','자기계발','인문학',
-  '여행','역사/문화','사회과학','정치/외교/국방','컴퓨터/IT','과학',
-  '외국어','예술/대중문화','아동/청소년',
-];
-const PARTICIPANTS = ['대학생','직장인','온라인','동아리원','오프라인','대면'];
+// 카테고리 옵션 (문자열 배열로 변환)
+const BOOK_CATEGORY_OPTIONS = Object.values(BOOK_CATEGORIES);
+
+// 참여자 유형 옵션 (문자열 배열로 변환)
+const PARTICIPANT_TYPE_OPTIONS = Object.values(PARTICIPANT_TYPES);
+
+// 카테고리 이름을 ID로 변환하는 함수
+const getCategoryId = (categoryName: string): number => {
+  const entry = Object.entries(BOOK_CATEGORIES).find(([id, name]) => name === categoryName);
+  return entry ? parseInt(entry[0]) : 1;
+};
+
+// 참여자 유형 이름을 키로 변환하는 함수
+const getParticipantKey = (participantName: string): string => {
+  const entry = Object.entries(PARTICIPANT_TYPES).find(([key, name]) => name === participantName);
+  return entry ? entry[0] : 'STUDENT';
+};
 
 export default function CreateClubPage(): React.ReactElement {
-  const [visibility, setVisibility] = useState<'공개' | '비공개' | null>(null);
+  const navigate = useNavigate();
+  const [open, setOpen] = useState<boolean | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedParticipants, setSelectedParticipants] = useState<string[]>([]);
   const [clubName, setClubName] = useState('');
+  const [clubDescription, setClubDescription] = useState('');
   const [duplicateCheck, setDuplicateCheck] = useState<'pending' | 'duplicate' | 'available' | null>(null);
-  const [sns1Link, setSns1Link] = useState('');
-  const [sns2Link, setSns2Link] = useState('');
+  const [instaLink, setInstaLink] = useState('');
+  const [kakaoLink, setKakaoLink] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 클럽 생성 핸들러
+  const handleCreateClub = async () => {
+    if (!clubName.trim()) {
+      alert('모임 이름을 입력해주세요.');
+      return;
+    }
+    if (!clubDescription.trim()) {
+      alert('모임 소개글을 입력해주세요.');
+      return;
+    }
+    if (open === null) {
+      alert('공개/비공개 여부를 선택해주세요.');
+      return;
+    }
+    if (selectedCategories.length === 0) {
+      alert('선호하는 독서 카테고리를 선택해주세요.');
+      return;
+    }
+    if (selectedParticipants.length === 0) {
+      alert('모임 참여 대상을 선택해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const clubData: Omit<ClubDto, 'clubId'> = {
+        name: clubName,
+        description: clubDescription,
+        open: open,
+        category: selectedCategories.map(getCategoryId),
+        participantTypes: selectedParticipants.map(getParticipantKey),
+        region: '서울', // 임시로 서울로 설정, 나중에 지역 선택 기능 추가 필요
+        insta: instaLink || undefined,
+        kakao: kakaoLink || undefined,
+      };
+
+      const response = await createClub(clubData);
+      if (response.isSuccess) {
+        alert('모임이 성공적으로 생성되었습니다!');
+        navigate('/searchClub'); // 모임 검색 페이지로 이동
+      } else {
+        alert(`모임 생성에 실패했습니다: ${response.message}`);
+      }
+    } catch (error: any) {
+      console.error('모임 생성 실패:', error);
+      if (error.response?.status === 409) {
+        alert('이미 존재하는 독서클럽 이름입니다.');
+      } else if (error.response?.status === 400) {
+        alert('유효하지 않은 카테고리가 입력되었습니다. (1 ~ 15 사이의 값이어야 함)');
+      } else {
+        alert('모임 생성에 실패했습니다. 다시 시도해주세요.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <div className="flex-1 p-8 min-h-screen">
@@ -74,9 +150,11 @@ export default function CreateClubPage(): React.ReactElement {
             모임의 소개글을 입력해주세요.
           </label>
           <textarea
+            value={clubDescription}
+            onChange={(e) => setClubDescription(e.target.value)}
             placeholder='내용을 입력해주세요.'
-            className="w-[808px] h-[265px] rounded-[16px] border-[2px] border-[#EAE5E2] px-[20px] py-[20px] text-[14px] text-[#BBBBBB] outline-none mt-[16px] resize-none"
-            />
+            className="w-[808px] h-[265px] rounded-[16px] border-[2px] border-[#EAE5E2] px-[20px] py-[20px] text-[14px] text-[#2C2C2C] outline-none mt-[16px] resize-none"
+          />
         </div>
 
         {/* 프로필 사진 업로드 */}
@@ -105,25 +183,25 @@ export default function CreateClubPage(): React.ReactElement {
           {/* 공개 버튼 */}
           <button
             type="button"
-            onClick={() => setVisibility('공개')}
+            onClick={() => setOpen(true)}
             className={`
               w-[178px] h-[53px]
               mt-[16px] flex flex-col items-center justify-center
               rounded-[36px] py-[10px]
               cursor-pointer
-              ${visibility === '공개' 
-                ? 'bg-[#90D26D] text-white' 
+              ${open === true
+                ? 'bg-[#90D26D] text-white'
                 : 'border-[1px] border-[#90D26D]'
               }
             `}
           >
             <span className={`font-pretendard font-semibold text-[12px] leading-[145%] tracking-[-0.1%] text-center ${
-              visibility === '공개' ? 'text-white' : 'text-[#2C2C2C]'
+              open === true ? 'text-white' : 'text-[#2C2C2C]'
             }`}>
               공개
             </span>
             <span className={`font-pretendard font-normal text-[12px] mt-[4px] ${
-              visibility === '공개' ? 'text-white' : 'text-[#8D8D8D]'
+              open === true ? 'text-white' : 'text-[#8D8D8D]'
             }`}>
               누구나 가입 가능
             </span>
@@ -132,25 +210,25 @@ export default function CreateClubPage(): React.ReactElement {
           {/* 비공개 버튼 */}
           <button
             type="button"
-            onClick={() => setVisibility('비공개')}
+            onClick={() => setOpen(false)}
             className={`
               w-[178px] h-[53px]
               mt-[16px] flex flex-col items-center justify-center
               rounded-[36px] py-[10px]
               cursor-pointer
-              ${visibility === '비공개' 
-                ? 'bg-[#90D26D] text-white' 
+              ${open === false
+                ? 'bg-[#90D26D] text-white'
                 : 'border-[1px] border-[#90D26D]'
               }
             `}
           >
             <span className={`font-pretendard font-semibold text-[12px] leading-[145%] tracking-[-0.1%] text-center ${
-              visibility === '비공개' ? 'text-white' : 'text-[#2C2C2C]'
+              open === false ? 'text-white' : 'text-[#2C2C2C]'
             }`}>
               비공개
             </span>
             <span className={`font-pretendard font-normal text-[12px] mt-[4px] ${
-              visibility === '비공개' ? 'text-white' : 'text-[#8D8D8D]'
+              open === false ? 'text-white' : 'text-[#8D8D8D]'
             }`}>
               운영자의 승인 필요
             </span>
@@ -166,7 +244,7 @@ export default function CreateClubPage(): React.ReactElement {
         </label>
         <div className="mt-[16px] max-w-[400px]">
           <ChipToggleGroup
-            options={BOOK_CATEGORIES}
+            options={BOOK_CATEGORY_OPTIONS}
             selected={selectedCategories}
             onToggle={(cat) => {
               if (selectedCategories.includes(cat)) {
@@ -186,7 +264,7 @@ export default function CreateClubPage(): React.ReactElement {
         </label>
         <div className="mt-[16px] max-w-[400px]">
           <ChipToggleGroup
-            options={PARTICIPANTS}
+            options={PARTICIPANT_TYPE_OPTIONS}
             selected={selectedParticipants}
             onToggle={(pt) => {
               if (selectedParticipants.includes(pt)) {
@@ -206,13 +284,13 @@ export default function CreateClubPage(): React.ReactElement {
         </label>
         <div className="mt-[16px] flex flex-col gap-[16px]">
           <input
-            value={sns1Link}
-            onChange={(e) => setSns1Link(e.target.value)}
+            value={instaLink}
+            onChange={(e) => setInstaLink(e.target.value)}
             className="w-[393px] h-[40px] bg-[#F6F5F3] rounded-full px-[17px] py-[10px] text-[14px] text-[#2C2C2C] outline-none placeholder:text-[#BBBBBB]"
           />
           <input
-            value={sns2Link}
-            onChange={(e) => setSns2Link(e.target.value)}
+            value={kakaoLink}
+            onChange={(e) => setKakaoLink(e.target.value)}
             className="w-[393px] h-[40px] bg-[#F6F5F3] rounded-full px-[17px] py-[10px] text-[14px] text-[#2C2C2C] outline-none placeholder:text-[#BBBBBB]"
           />
         </div>

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -23,10 +23,47 @@ export type RecommendationDto = {
 };
 
 export type ClubDto = {
-  clubId: number;
+  clubId?: number; // 생성 시에는 없고, 조회 시에는 있음
   name: string;
   description: string;
+  profileImageUrl?: string;
+  open: boolean; // 공개/비공개 여부
+  category: number[]; // 카테고리 ID 배열 (1~15)
+  participantTypes: string[]; // 참여자 유형 배열
+  region: string;
+  purpose?: string;
+  insta?: string;
+  kakao?: string;
 };
+
+// 카테고리 상수
+export const BOOK_CATEGORIES = {
+  1: '국내도서',
+  2: '소설/시/희곡',
+  3: '에세이',
+  4: '경제/경영',
+  5: '자기계발',
+  6: '인문학',
+  7: '여행',
+  8: '역사/문화',
+  9: '사회과학',
+  10: '정치/외교/국방',
+  11: '컴퓨터/IT',
+  12: '과학',
+  13: '외국어',
+  14: '예술/대중문화',
+  15: '어린이 도서'
+} as const;
+
+// 참여자 유형 상수
+export const PARTICIPANT_TYPES = {
+  STUDENT: '대학생',
+  WORKER: '직장인',
+  ONLINE: '온라인',
+  CLUB: '동아리',
+  MEETING: '모임',
+  OFFLINE: '대면'
+} as const;
 
 export type MeetingDto = {
   meetingId: number;


### PR DESCRIPTION
#61 [feat] 독서모임 검색하기 카테고리 태그 재구현 및 api 관련 수정

독서모임 검색하기 페이지에서 태그가 기수, 독서 카테고리에서 독서 카테고리만 보이게 수정했습니다.
동시에 API 스펙을 참고해서 clubApi.ts 파일을 생성했으며, clubCard.tsx 파일을 수정했고, dto.ts 파일에서 club관련 type을 수정했습니다.
또한 추후에 api 연동이 쉽도록 ClubSearchPage.tsx 와 createClubPage.tsx 파일 코드를 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 동아리 목록 조회, 동아리 생성, 상세 조회, 검색 등 동아리 관련 API 연동이 추가되었습니다.
  * 동아리 생성 시 카테고리, 참여자 유형, 공개/비공개, SNS 링크 등 다양한 정보를 입력할 수 있습니다.

* **기능 개선**
  * 동아리 카드에 카테고리와 참여자 유형 정보가 태그 형태로 표시됩니다.
  * 동아리 검색 및 필터링이 참여자 유형 기준으로 개선되었습니다.

* **버그 수정**
  * 동아리 생성 시 입력값 검증 및 오류 메시지 안내가 추가되었습니다.

* **리팩터링/스타일**
  * 동아리 카드와 생성 페이지의 UI가 개선되었습니다.
  * 데이터 구조가 실제 동아리 정보를 반영하도록 현실적으로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->