### PR TITLE
[refactor] 독서모임 공지사항 페이지 더미 데이터 추가, 헤더 연결 및  중요 공지사항 카드 UI 수정

### DIFF
--- a/src/components/BookClub/AnnouncementCard.tsx
+++ b/src/components/BookClub/AnnouncementCard.tsx
@@ -37,10 +37,12 @@ export default function AnnouncementCard({
   items: AnnouncementCardProps[];
 }): React.ReactElement {
   return (
-    <div className="flex gap-[24px]">
-      {items.map((item, idx) => (
-        <AnnouncementCardItem key={idx} item={item} />
-      ))}
+    <div className="overflow-x-auto">
+      <div className="flex gap-[24px] min-w-max">
+        {items.map((item, idx) => (
+          <AnnouncementCardItem key={idx} item={item} />
+        ))}
+      </div>
     </div>
   );
 }
@@ -128,13 +130,14 @@ function AnnouncementCardItem({
             <div className="absolute top-[80px] right-[24px]">
              <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-2" />
             </div>
-            <div className="absolute bottom-[20px] left-1/2 transform -translate-x-1/2">
+            <div className="absolute bottom-[24.5px]">
               <div
                 className="
                   relative
                   w-[262px] h-[232px]
                   bg-gray-100 rounded-lg
                   overflow-hidden
+                  flex items-center justify-center
                 "
               >
                 {item.imageUrl

--- a/src/pages/BookClub/NoticePage.tsx
+++ b/src/pages/BookClub/NoticePage.tsx
@@ -1,6 +1,7 @@
 import AnnouncementCard, { type AnnouncementCardProps } from '../../components/BookClub/AnnouncementCard';
 import AnnouncementList, { type AnnouncementListItemProps } from '../../components/BookClub/AnnouncementList';
 import checkerImage from "../../assets/images/checker.png";
+import Header from '../../components/Header';
 
 export default function HomePage(): React.ReactElement {
   // 공지사항 더미 데이터
@@ -34,6 +35,29 @@ export default function HomePage(): React.ReactElement {
       announcementTitle: '북적 북적 엠티가돌아왔다~',
       announcement: '🌲 북적북적 엠티 공지\n 📚 올해도 어김없이 북적이들의 소풍이 돌아왔습니다!\n 책 덮고 자연 속으로, 잠시 감성을 충전하러 떠나요✨\n ✔️ 날짜 / 장소 / 투표: [바로가기]',
     },
+    {
+      title: '북적북적',
+      tag: '모임',
+      meetingDate: '2025.06.12',  
+      book: '넥서스',
+      imageUrl: checkerImage,    // 나중에 실제 URL로 교체
+    },
+    {
+      title: '5/24 모임 투표',
+      tag: '투표',
+      meetingDate: '2025.06.12 · 18시',
+      meetingPlace: '홍대 9번 출구',
+      afterPartyPlace: '반주시대',
+      voteOptions: [
+        { label: '참여', value: 'yes' },
+        { label: '토론만 참여', value: 'talk' },
+        { label: '불참', value: 'no' },
+      ],
+      onVoteSubmit: (selectedValue) => {
+        console.log(`Selected vote: ${selectedValue}`);
+        // 투표 처리 로직
+      },
+    },
   ];
 
   const listItems: AnnouncementListItemProps[] = [
@@ -65,13 +89,40 @@ export default function HomePage(): React.ReactElement {
       announcementTitle: '북적 북적 엠티가돌아왔다~',
       announcement: '🌲 북적북적 엠티 공지\n 📚 올해도 어김없이 북적이들의 소풍이 돌아왔습니다!\n 책 덮고 자연 속으로, 잠시 감성을 충전하러 떠나요✨\n ✔️ 날짜 / 장소 / 투표: [바로가기]',
     },
+    {
+      id: 4,
+      title: '05.24 | 토론 모임 (8)',
+      clubName: '북적북적',
+      tag: '모임',
+      imageUrl: checkerImage,
+      meetingDate: '2025.06.12',
+      book: '넥서스',
+      bookAuthor: '유발하리리',
+    },
+    {
+      id: 5,
+      title: '5/24 모임 투표',
+      clubName: '북적북적',
+      tag: '투표',
+      imageUrl: checkerImage,
+      meetingDate: '2025.06.12 18:00',
+      meetingPlace: '홍대 9번 출구',
+      afterPartyPlace: '반주시대',
+    },
   ];
 
   return (
     <div className="w-[1083px] flex-1 mt-[36px] ml-[52px] min-h-screen">
+      <Header pageTitle={'공지사항'} userProfile={{
+          username: 'Dayoun',
+          bio: '아 피곤하다.'
+        }} 
+        notifications={[]}
+        customClassName="mt-15 mb-10"
+      />
         {/* 상단: 중요 공지사항 */}
         <section>
-          <AnnouncementCard items={dummyAnnouncements} />
+          <AnnouncementCard items={dummyAnnouncements.slice(0, 5)} />
         </section>
 
         {/* 하단: 공지사항 목록*/}


### PR DESCRIPTION
1. npm install @tailwindcss/line-clamp 설치 (노션-초기세팅 회의록 부분에 추가해 놓을까요?)
2. 헤더 연결
3. 더미데이터 개수 추가
4. 상단 중요 공지사항 부분 CSS 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 페이지 상단에 새로운 헤더가 추가되었습니다.
* **Style**
  * 공지 카드 목록이 가로 스크롤이 가능하도록 개선되었습니다.
  * 카드 내 이미지 및 태그의 정렬이 더욱 깔끔하게 조정되었습니다.
* **기타**
  * 공지 더미 데이터가 추가되어 더 다양한 예시를 확인할 수 있습니다.
  * 공지 카드는 최대 5개까지만 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->