### PR TITLE
[refactor] 독서모임 공지사항 페이지 라우팅 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ const App = () => {
             <Route path="/home" element={<HomePage />} />
             <Route path="/booksearch" element={<SearchPage />} />
             <Route path="/searchClub" element={<ClubSearchPage />} />
+            <Route path="/bookClub/notices" element={<NoticePage />} />
             {/* 마이페이지 하위 라우트 */}
             <Route path="/mypage/group" element={<MyGroupPage />} />
             <Route
@@ -86,7 +87,7 @@ const App = () => {
             <Route index element={<BookClubHomePage />} />
 
             {/* /bookclub/notices → 공지사항 페이지 */}
-            <Route path="notices" element={<NoticePage />} />
+            
             <Route path=":id" element={<Layout />}>
               <Route path="home" element={<BookClubHomePage />} />
 


### PR DESCRIPTION
독서모임 공지사항 사이드바 연결 위해, App.tsx에서 라우팅 <Route element={<Layout />}></Route> 안으로 이동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 공지사항 페이지가 이제 "/bookClub/notices" 경로에서 메인 레이아웃 하위로 이동되었습니다.

* **Refactor**
  * 기존 "/bookclub/notices" 경로의 중첩 라우트가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->