### PR TITLE
[Style] shelf , searchpage의 Sidebar 연결 (#86)

### DIFF
--- a/src/components/ClubSideBar.tsx
+++ b/src/components/ClubSideBar.tsx
@@ -54,9 +54,9 @@ const ClubSideBar = () => {
       name: "책 검색하기",
       icon: searchIcon,
       submenus: [
-        { name: "통합검색", path: `/bookclub/${id}` },
-        { name: "국내도서", path: "/domesticBook" },
-        { name: "전자책", path: "/ebook" },
+        { name: "통합검색", path: "/booksearch" },
+        { name: "국내도서", path: "/booksearch" },
+        { name: "전자책", path: "/booksearch" },
       ],
     },
     {

--- a/src/components/Search/BookSearch.tsx
+++ b/src/components/Search/BookSearch.tsx
@@ -9,6 +9,7 @@ export interface Book {
   summary1: string
   summary2: string
   coverUrl?: string
+  translator? : string
 }
 
 export interface Action {

--- a/src/components/Search/SearchedBookModal.tsx
+++ b/src/components/Search/SearchedBookModal.tsx
@@ -1,0 +1,89 @@
+// src/components/SearchedBookModal.tsx
+import React, { useEffect } from "react";
+import ReactDOM from "react-dom";
+import type { Book } from "../../components/Search/BookSearch";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  book: Book;
+}
+
+export default function SearchedBookModal({ isOpen, onClose, book }: Props) {
+  if (!isOpen) return null;
+
+  return ReactDOM.createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/25">
+      {/* 모달 창 */}
+      <div className="relative h-[572px] w-[1090px] bg-white rounded-2xl shadow-xl">
+        {/* 닫기 버튼 */}
+        <button
+          className="absolute top-4 right-4 text-2xl text-gray-400 hover:text-gray-600"
+          onClick={onClose}
+        >
+          ×
+        </button>
+
+        {/* 내부 콘텐츠: 30px 패딩 + flex 레이아웃 */}
+        <div className="absolute inset-[30px] flex">
+          {/* 좌측 커버 */}
+          <div className="flex-shrink-0 h-[512px] w-[362px] overflow-hidden rounded-md bg-gray-100">
+            {book.coverUrl ? (
+              <img
+                src={book.coverUrl}
+                alt={`${book.title} cover`}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-gray-400">
+                No Image
+              </div>
+            )}
+          </div>
+
+          {/* 좌우 간격 30px */}
+          <div className="w-[30px]" />
+
+          {/* 우측 컨텐츠 */}
+          <div className="flex flex-1 flex-col">
+            {/* 제목 / 메타 */}
+            <div>
+              <h2 className="text-[var(--Gray-1)] font-[Pretendard] text-[32px] font-bold leading-[135%] tracking-[-0.032px]">
+                {book.title}
+              </h2>
+              <p className="mt-1 text-sm text-gray-500">
+                유발 하라리 | 김병주 옮김 | 출판 김영사 | 2024.10.11
+              </p>
+            </div>
+
+            {/* 설명 영역 (스크롤 가능) */}
+            <div className="mt-9 flex-1 overflow-y-auto text-gray-700 leading-relaxed">
+              {book.summary1 || "설명이 없습니다."}
+            </div>
+
+            {/* 액션 버튼 */}
+            <div className="mt-6 flex justify-end space-x-2">
+              <button
+                className="rounded-lg px-4 py-2 bg-gray-200 text-gray-700 hover:bg-gray-300"
+                onClick={onClose}
+              >
+                닫기
+              </button>
+              <button
+                className="rounded-lg px-4 py-2 bg-[var(--button-brown,#A6917E)] text-white hover:brightness-90"
+                onClick={() => {
+                  // 예: 책 이야기 페이지로 이동
+                  // navigate(`/bookstory/${book.id}`);
+                  onClose();
+                }}
+              >
+                책 이야기
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -59,7 +59,7 @@ const Sidebar = () => {
           icon: homeIcon,
           submenus: [
             { name: "공지사항", path: `/bookclub/${id}/notice` },
-            { name: "책장", path: `/bookclub/${id}/bookcase` },
+            { name: "책장", path: `/bookclub/${id}/shelf` },
             { name: "모임", path: `/bookclub/${id}/meeting` },
             { name: "책 추천", path: `/bookclub/${id}/recommend` },
             { name: "일정", path: `/bookclub/${id}/schedule` },
@@ -69,9 +69,9 @@ const Sidebar = () => {
           name: "책 검색하기",
           icon: searchIcon,
           submenus: [
-            { name: "통합검색", path: `/bookclub/${id}` },
-            { name: "국내도서", path: "/domesticBook" },
-            { name: "전자책", path: "/ebook" },
+            { name: "통합검색", path: "/booksearch" },
+            { name: "국내도서", path: "/booksearch" },
+            { name: "전자책", path: "/booksearch" },
           ],
         },
         {
@@ -112,12 +112,12 @@ const Sidebar = () => {
         },
         {
           name: "책 검색하기",
-          path: "/search",
+          path: "/booksearch",
           icon: searchIcon,
           submenus: [
-            { name: "통합검색", path: "/bookclub/:id" },
-            { name: "국내도서", path: "/domesticBook" },
-            { name: "전자책", path: "/ebook" },
+            { name: "통합검색", path: "/booksearch" },
+            { name: "국내도서", path: "booksearch1" },
+            { name: "전자책", path: "/booksearch2" },
           ],
         },
         {

--- a/src/pages/Main/SearchPage.tsx
+++ b/src/pages/Main/SearchPage.tsx
@@ -5,9 +5,13 @@ import BookSearch, {
   type Action,
 } from "../../components/Search/BookSearch";
 import Header from "../../components/Header"
+import SearchedBookModal from "../../components/Search/SearchedBookModal"
+import { useState } from "react";
 
 export default function SearchPage() {
   const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+  const [bookDetail, setbookDetail] = useState<Book | null>(null);
 
   const actions: Action[] = [
     {
@@ -22,8 +26,8 @@ export default function SearchPage() {
     {
       label: "상세 보기",
       onClick: (book: Book) => {
-        // 상세 보기 페이지로 이동
-        navigate(`/bookdetail/${book.id}`);
+        setbookDetail(book);
+        setIsOpen(true);
       },
       className:
         "bg-[var(--button-brown,#FFF] text-black border-[1.5px] border-[var(--sub-color-1-brown,#BFAB96)]",
@@ -31,15 +35,28 @@ export default function SearchPage() {
   ];
 
   return (
-    <div className="flex h-screen ">
+
+    <div>
+      <div className="flex h-screen ">
       <div className="absolute left-[315px] right-[42px] opacity-100 ">
-        <Header pageTitle="통합검색" customClassName="mt-15" />
+        <Header pageTitle={'통합검색'} userProfile={{
+          username: 'Luke',
+          bio: '아 피곤하다.'
+        }} 
+        notifications={[]}
+        customClassName="mt-15"
+        />
         
         {/* 메인 컨텐츠 자리 */}
         <div className = "">
           <BookSearch SearchResultHeight = {235} actions={actions}/>
         </div>
       </div>
+      {bookDetail && <SearchedBookModal isOpen={isOpen} onClose={() => setIsOpen(false)} book={bookDetail} /> }
+      
+
+      </div>
     </div>
+    
   );
 }


### PR DESCRIPTION
Sidebar 만 보시면 됩니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 도서 상세 정보를 보여주는 모달 창이 추가되어, 검색 결과에서 "상세 보기" 클릭 시 모달로 상세 정보를 확인할 수 있습니다.

* **버그 수정**
  * 사이드바의 "책 검색하기" 및 관련 서브메뉴 경로가 통일되고 일부 경로 명칭이 변경되었습니다.
  * 북클럽 내 "책장" 메뉴 경로가 변경되었습니다.

* **기타**
  * 검색 결과에서 "책 이야기" 버튼은 기존과 동일하게 별도 페이지로 이동합니다.
  * 도서 정보에 번역가 항목이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->