### PR TITLE
[feat] 운영진 독서모임 공지사항 홈화면 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import GroupManagementPage from "./pages/Manage/GroupManagementPage";
 import MeetingDetailPage from "./pages/Meeting/MeetingDetailPage";
 import CreateMeetingPage from "./pages/Meeting/CreateMeetingPage";
 import MeetingTopicListPage from "./pages/Meeting/MeetingTopicListPage";
+import NoticeManagementPage from "./pages/Manage/NoticeManagementPage";
 
 
 const App = () => {
@@ -61,6 +62,7 @@ const App = () => {
             {/* 운영진 */}
             <Route path="manage">
               <Route path="group" element={<GroupManagementPage />} />
+              <Route path="notices" element={<NoticeManagementPage />} /> {/* 임시 */}
             </Route>
 
             {/* 마이페이지 */}

--- a/src/components/BookClub/AnnouncementCard.tsx
+++ b/src/components/BookClub/AnnouncementCard.tsx
@@ -235,20 +235,13 @@ function AnnouncementCardItem({
 
         <div className="mt-[9px]">
         {item.tag === '공지' && (
-          <div className="
-            font-pretendard      
+          <div className="   
             font-normal           
             text-[12px]           
-            leading-[145%]        
-            tracking-[-0.1%]      
             text-[#000000]
             space-y-[4px]    
              ">
-            <p className="font-pretendard font-normal text-[12px] leading-[145%] tracking-[-0.1%]">{item.announcementTitle}</p>
-            <p className="mt-[24px] font-pretendard font-normal text-[12px] leading-[145%] tracking-[-0.1%] whitespace-pre-line">{item.announcement}</p>
-            <div className="absolute top-[80px] right-[24px]">
-             <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-2" />
-            </div>
+            <p className="mt-[24px] font-normal text-[12px] whitespace-pre-line">{item.announcement}</p>
           </div>
         )}
         </div>

--- a/src/components/BookClub/AnnouncementList.tsx
+++ b/src/components/BookClub/AnnouncementList.tsx
@@ -39,7 +39,7 @@ export default function AnnouncementList({
           key={item.id}
           onClick={() => handleItemClick(item)}
           className="
-            w-[1083px] h-[204px]
+            w-full h-[204px]
             relative flex items-start
             bg-white border-[2px] border-[#EAE5E2] rounded-[16px]
             cursor-pointer

--- a/src/components/BookClub/NoticeCreateHoverMenu.tsx
+++ b/src/components/BookClub/NoticeCreateHoverMenu.tsx
@@ -1,0 +1,89 @@
+import { useState, useRef, useEffect } from 'react';
+
+interface NoticeCreateDropdownProps {
+  onSelectNoticeType: (type: 'general' | 'vote') => void;
+  className?: string;
+}
+
+export default function NoticeCreateDropdown({ 
+  onSelectNoticeType, 
+  className = '' 
+}: NoticeCreateDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsOpen(true);
+  };
+
+  const handleMouseLeave = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, 200); // 200ms 지연으로 실수로 닫히는 것 방지
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleSelectType = (type: 'general' | 'vote') => {
+    onSelectNoticeType(type);
+    setIsOpen(false);
+  };
+
+    return (
+    <div 
+      ref={dropdownRef} 
+      className={`relative ${className}`}
+    >
+      {/* 버튼 컨테이너 */}
+      <div 
+        className="w-[204px] absolute right-0 flex justify-center"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {/* 메인 버튼 */}
+        <button 
+          className="w-full h-[48px] bg-[#F6F3F0] rounded-[100px]
+          font-medium text-[18px] text-[#2C2C2C]
+          cursor-pointer
+          hover:bg-[#EDE8E3] transition-colors duration-200
+          flex items-center justify-center
+          "
+        >
+          + 새 공지 작성하기
+        </button>
+
+        {/* 호버 메뉴 */}
+        {isOpen && (
+          <div className="absolute top-[55px] left-1/2 transform -translate-x-1/2 w-[155px] bg-white border-[2px] border-[#EAE5E2] rounded-[16px]">
+          <div className="p-[10px] h-[108px] font-medium text-[18px] text-[#BBBBBB]">
+            <button
+              onClick={() => handleSelectType('general')}
+              className="w-full h-[44px] border-b-[2px] border-[#EAE5E2] flex justify-center items-center
+              cursor-pointer hover:text-[#2C2C2C] transition-colors duration-200"
+            >
+              일반 공지
+            </button>
+            <button
+              onClick={() => handleSelectType('vote')}
+              className="w-full h-[44px] flex justify-center items-center
+              cursor-pointer hover:text-[#2C2C2C] transition-colors duration-200"
+            >
+              투표 공지
+            </button>
+          </div>
+        </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Manage/NoticeManagementPage.tsx
+++ b/src/pages/Manage/NoticeManagementPage.tsx
@@ -126,31 +126,35 @@ export default function NoticeManagementPage(): React.ReactElement {
   ];
 
   return (
-    <div className="w-full h-full">
-      <div className="flex-1 mt-[36px] ml-[52px] min-h-screen">
+    <div className="w-full h-screen flex flex-col">
         <Header pageTitle={'공지사항'} userProfile={{
           username: 'Dayoun',
           bio: '아 피곤하다.'
         }} 
         notifications={[]}
-        customClassName="mt-15 mb-10"
+        customClassName="mt-[60px] ml-[52px] mr-[41px] mb-[36px]"
       />
-      {/* 상단: 중요 공지사항 */}
-      <section>
-        <AnnouncementCard items={dummyAnnouncements.slice(0, 5)} />
-      </section>
 
-      {/* 하단: 공지사항 목록*/}
-      <section className="mt-[43px] relative">
-        <NoticeCreateDropdown 
-          onSelectNoticeType={handleNoticeTypeSelect}
-          className="z-10"
-        />
-        <div className="pt-[69px]">
-          <AnnouncementList items={listItems} />
+      {/* 메인 컨텐츠 - 남은 공간을 모두 사용하며 스크롤 */}
+      <div className="flex-1 overflow-y-auto ml-[52px] mr-4">
+        <div className="pb-8">
+          {/* 상단: 중요 공지사항 */}
+          <section className="mb-6">
+            <AnnouncementCard items={dummyAnnouncements.slice(0, 5)} />
+          </section>
+
+          {/* 하단: 공지사항 목록*/}
+          <section className="mt-[43px] relative">
+            <NoticeCreateDropdown 
+              onSelectNoticeType={handleNoticeTypeSelect}
+              className="z-10"
+            />
+            <div className="pt-[69px] pb-12">
+              <AnnouncementList items={listItems} />
+            </div>
+          </section>
         </div>
-      </section>
+      </div>
     </div>
-  </div>
   );
 }

--- a/src/pages/Manage/NoticeManagementPage.tsx
+++ b/src/pages/Manage/NoticeManagementPage.tsx
@@ -1,0 +1,156 @@
+import AnnouncementCard from '../../components/BookClub/AnnouncementCard';
+import AnnouncementList from '../../components/BookClub/AnnouncementList';
+import NoticeCreateDropdown from '../../components/BookClub/NoticeCreateHoverMenu';
+import type { AnnouncementProps } from '../../types/announcement';
+import checkerImage from "../../assets/images/checker.png";
+import Header from '../../components/Header';
+
+export default function NoticeManagementPage(): React.ReactElement {
+  console.log('NoticeManagementPage rendering...');
+
+  const handleNoticeTypeSelect = (type: 'general' | 'vote') => {
+    console.log(`Selected notice type: ${type}`);
+    // TODO: 공지 작성 페이지로 이동하는 로직 추가
+    // 예: navigate(`/manage/notice/create?type=${type}`);
+  };
+  // 공지사항 더미 데이터
+  const dummyAnnouncements: AnnouncementProps[] = [
+    {
+      id: 1,
+      title: '북적북적',
+      tag: '모임',
+      meetingDate: '2025.06.12',  
+      book: '넥서스',
+      imageUrl: checkerImage,    // 나중에 실제 URL로 교체
+    },
+    {
+      id: 2,
+      title: '5/24 모임 투표',
+      tag: '투표',
+      meetingDate: '2025.06.12 · 18시',
+      meetingPlace: '홍대 9번 출구',
+      afterPartyPlace: '반주시대',
+      voteOptions: [
+        { id: '1', label: '참여', value: 'yes' },
+        { id: '2', label: '토론만 참여', value: 'talk' },
+        { id: '3', label: '불참', value: 'no' },
+      ],
+      onVoteSubmit: (selectedValues: string[]) => {
+        console.log(`Selected votes: ${selectedValues}`);
+        // 투표 처리 로직
+      },
+    },
+    {
+      id: 3,
+      title: '북적북적 MT 공지',
+      tag: '공지',
+      announcementTitle: '북적 북적 엠티가돌아왔다~',
+      announcement: '🌲 북적북적 엠티 공지\n 📚 올해도 어김없이 북적이들의 소풍이 돌아왔습니다!\n 책 덮고 자연 속으로, 잠시 감성을 충전하러 떠나요✨\n ✔️ 날짜 / 장소 / 투표: [바로가기]',
+    },
+    {
+      id: 4,
+      title: '북적북적',
+      tag: '모임',
+      meetingDate: '2025.06.12',  
+      book: '넥서스',
+      imageUrl: checkerImage,    // 나중에 실제 URL로 교체
+    },
+    {
+      id: 5,
+      title: '5/24 모임 투표',
+      tag: '투표',
+      meetingDate: '2025.06.12 · 18시',
+      meetingPlace: '홍대 9번 출구',
+      afterPartyPlace: '반주시대',
+      voteOptions: [
+        { id: '1', label: '참여', value: 'yes' },
+        { id: '2', label: '토론만 참여', value: 'talk' },
+        { id: '3', label: '불참', value: 'no' },
+      ],
+      onVoteSubmit: (selectedValues: string[]) => {
+        console.log(`Selected votes: ${selectedValues}`);
+        // 투표 처리 로직
+      },
+    },
+  ];
+
+  const listItems: AnnouncementProps[] = [
+    {
+      id: 1,
+      title: '05.24 | 토론 모임 (8)',
+      clubName: '북적북적',
+      tag: '모임',
+      imageUrl: checkerImage,
+      meetingDate: '2025.06.12',
+      book: '넥서스',
+      bookAuthor: '유발하리리',
+    },
+    {
+      id: 2,
+      title: '5/24 모임 투표',
+      clubName: '북적북적',
+      tag: '투표',
+      imageUrl: checkerImage,
+      meetingDate: '2025.06.12 18:00',
+      meetingPlace: '홍대 9번 출구',
+      afterPartyPlace: '반주시대',
+    },
+    {
+      id: 3,
+      title: '북적북적 공지',
+      tag: '공지',
+      imageUrl: checkerImage,
+      announcementTitle: '북적 북적 엠티가돌아왔다~',
+      announcement: '🌲 북적북적 엠티 공지\n 📚 올해도 어김없이 북적이들의 소풍이 돌아왔습니다!\n 책 덮고 자연 속으로, 잠시 감성을 충전하러 떠나요✨\n ✔️ 날짜 / 장소 / 투표: [바로가기]',
+    },
+    {
+      id: 4,
+      title: '05.24 | 토론 모임 (8)',
+      clubName: '북적북적',
+      tag: '모임',
+      imageUrl: checkerImage,
+      meetingDate: '2025.06.12',
+      book: '넥서스',
+      bookAuthor: '유발하리리',
+    },
+    {
+      id: 5,
+      title: '5/24 모임 투표',
+      clubName: '북적북적',
+      tag: '투표',
+      imageUrl: checkerImage,
+      meetingDate: '2025.06.12 18:00',
+      meetingPlace: '홍대 9번 출구',
+      afterPartyPlace: '반주시대',
+    },
+  ];
+
+  return (
+    <div className="w-full h-full">
+      <div className="flex-1 mt-[36px] ml-[52px] min-h-screen">
+        <Header pageTitle={'공지사항'} userProfile={{
+          username: 'Dayoun',
+          bio: '아 피곤하다.'
+        }} 
+        notifications={[]}
+        customClassName="mt-15 mb-10"
+      />
+      {/* 상단: 중요 공지사항 */}
+      <section>
+        <AnnouncementCard items={dummyAnnouncements.slice(0, 5)} />
+      </section>
+
+      {/* 하단: 공지사항 목록*/}
+      <section className="mt-[43px] relative">
+        <NoticeCreateDropdown 
+          onSelectNoticeType={handleNoticeTypeSelect}
+          className="z-10"
+        />
+        <div className="pt-[69px]">
+          <AnnouncementList items={listItems} />
+        </div>
+      </section>
+    </div>
+  </div>
+  );
+}


### PR DESCRIPTION
# 제목 [feat] 운영진 독서모임 공지사항 홈화면 구현

## 작업내용

- [ ] 구현내용 1
운영진 공지사항 홈화면 UI 구현
- [ ] 구현내용 2
공지 생성하기 관련 호버 메뉴 컴포넌트 생성
- [ ] 구현내용 3
공지사항 announcementCard.tsx의 일반 공지 UI 수정

## 구현 영상
https://github.com/user-attachments/assets/579a62b2-ef11-4610-8813-e4fcd9f08244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리 페이지 내에 공지 관리 인터페이스가 추가되었습니다.
  * 공지 작성 드롭다운 메뉴가 도입되어, 일반 공지와 투표 공지 유형을 선택할 수 있습니다.
  * 관리 경로에 공지 관리 페이지 접근을 위한 임시 라우트가 추가되었습니다.

* **개선 사항**
  * 공지 카드의 레이아웃이 간소화되어 가독성이 향상되었습니다.
  * 공지 리스트의 폭이 반응형으로 변경되어 다양한 화면에서 더 잘 보이도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->