### PR TITLE
[chore] 독서모임 공지사항 홈화면 헤더 디테일 수정

### DIFF
--- a/src/pages/BookClub/NoticePage.tsx
+++ b/src/pages/BookClub/NoticePage.tsx
@@ -119,17 +119,18 @@ export default function HomePage(): React.ReactElement {
   ];
 
   return (
-    <div className="absolute left-[315px] right-[42px] opacity-100 h-screen flex flex-col">
-      <Header pageTitle={'공지사항'} userProfile={{
-        username: 'dayoun',
-        bio: '아 피곤하다.'
-      }} 
-      notifications={[]}
-      customClassName="mt-[30px]"
+    <div className="w-full h-screen flex flex-col">
+        <Header pageTitle={'공지사항'} userProfile={{
+          username: 'dayoun',
+          bio: '아 피곤하다.'
+        }} 
+        notifications={[]}
+        customClassName="mt-[30px] ml-[52px] mr-[41px]"
       />
 
       {/* 메인 컨텐츠 - 남은 공간을 모두 사용하며 스크롤 */}
-      <div className="flex-1 overflow-y-auto mt-[15px] ml-[52px] mr-4 pb-8">
+      <div className="flex-1 overflow-y-auto ml-[52px] mr-4">
+        <div className="mt-[15px]">
         {/* 상단: 중요 공지사항 */}
         <section className="mb-6">
           <AnnouncementCard items={dummyAnnouncements.slice(0, 5)} />
@@ -139,6 +140,7 @@ export default function HomePage(): React.ReactElement {
         <section className="mt-[43px]">
           <AnnouncementList items={listItems} />
         </section>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/BookClub/NoticePage.tsx
+++ b/src/pages/BookClub/NoticePage.tsx
@@ -129,7 +129,7 @@ export default function HomePage(): React.ReactElement {
       />
 
       {/* 메인 컨텐츠 - 남은 공간을 모두 사용하며 스크롤 */}
-      <div className="flex-1 overflow-y-auto ml-[52px] mr-4 pb-8">
+      <div className="flex-1 overflow-y-auto mt-[15px] ml-[52px] mr-4 pb-8">
         {/* 상단: 중요 공지사항 */}
         <section className="mb-6">
           <AnnouncementCard items={dummyAnnouncements.slice(0, 5)} />

--- a/src/pages/BookClub/NoticePage.tsx
+++ b/src/pages/BookClub/NoticePage.tsx
@@ -119,13 +119,13 @@ export default function HomePage(): React.ReactElement {
   ];
 
   return (
-    <div className="w-full h-screen flex flex-col">
+    <div className="absolute left-[315px] right-[42px] opacity-100 h-screen flex flex-col">
       <Header pageTitle={'공지사항'} userProfile={{
-        username: 'Dayoun',
+        username: 'dayoun',
         bio: '아 피곤하다.'
       }} 
       notifications={[]}
-      customClassName="mt-[30px] ml-[52px] mr-[41px] mb-[36px]"
+      customClassName="mt-[30px]"
       />
 
       {/* 메인 컨텐츠 - 남은 공간을 모두 사용하며 스크롤 */}


### PR DESCRIPTION
# 제목 [chore] 독서모임 공지사항 홈화면 헤더 디테일 수정

## 작업내용

1. 독서모임 공지사항 홈화면 헤더 디테일 수정

## 구현사진

<img width="1920" height="1020" alt="Image" src="https://github.com/user-attachments/assets/1ce814ca-a7f1-4120-9b49-65ba322b4caa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 페이지 레이아웃의 위치 및 여백 스타일이 조정되었습니다.
  * Header의 사용자 이름 표기가 소문자로 변경되었습니다.
  * Header의 마진 클래스가 단순화되었습니다.
  * 메인 콘텐츠 영역에 상단 마진이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->