### PR TITLE
[feat] 북클럽 검색 페이지 API 연동

### DIFF
--- a/src/apis/clubApi.ts
+++ b/src/apis/clubApi.ts
@@ -1,4 +1,4 @@
-import type { ClubDto, CreateClubRequestDto, ClubListResult } from "../types/bookClub";
+import type { ClubDto, CreateClubRequestDto, ClubListResult, JoinClubRequest, JoinClubResult } from "../types/bookClub";
 import { axiosInstance } from "./axiosInstance";
 
 // 클럽 생성
@@ -28,5 +28,14 @@ export const fetchClubList = async (
       cursorId: params.cursorId ?? undefined,
     },
   });
+  return result;
+};
+
+// 클럽 가입 신청
+export const requestJoinClub = async (
+  clubId: number,
+  payload: JoinClubRequest
+): Promise<JoinClubResult> => {
+  const result: JoinClubResult = await axiosInstance.post(`/clubs/${clubId}/join`, payload);
   return result;
 };

--- a/src/apis/clubApi.ts
+++ b/src/apis/clubApi.ts
@@ -1,18 +1,32 @@
-import type { ClubDto, CreateClubRequestDto } from "../types/bookClub";
+import type { ClubDto, CreateClubRequestDto, ClubListResult } from "../types/bookClub";
 import { axiosInstance } from "./axiosInstance";
 
 // 클럽 생성
 export const createClub = async (clubData: CreateClubRequestDto): Promise<ClubDto> => {
-  const { data } = await axiosInstance.post<ClubDto>('/clubs', clubData);
-  return data;
+  const response: ClubDto = await axiosInstance.post('/clubs', clubData);
+  return response;
 };
 
-// 클럽 상세 조회
-export const getClubDetail = async (clubId: number): Promise<ClubDto> =>
-  axiosInstance.get<ClubDto>(`/api/clubs/${clubId}`).then((r) => r.data);
+// 클럽 목록 조회
+export type ClubSearchParams = {
+  keyword?: string;
+  region?: 0 | 1; // 0=전체, 1=지역 필터 적용
+  participants?: 0 | 1; // 0=전체, 1=대상 유형 필터 적용
+  cursorId?: number | null; // 해당 ID보다 작은 클럽만 조회
+  size?: number; // 페이지 사이즈
+};
 
-// 클럽 검색
-export const searchClubs = async (query: string): Promise<ClubDto[]> =>
-  axiosInstance
-    .get<ClubDto[]>(`/api/clubs/search?q=${encodeURIComponent(query)}`)
-    .then((r) => r.data);
+// 검색/목록 조회 (커서 기반)
+export const fetchClubList = async (
+  params: ClubSearchParams
+): Promise<ClubListResult> => {
+  // axiosInstance는 성공 시 data.result를 반환하도록 인터셉터가 설정되어 있음
+  const result: ClubListResult = await axiosInstance.get('/clubs/search', {
+    params: {
+      ...params,
+      // null 커서는 보내지 않도록 처리
+      cursorId: params.cursorId ?? undefined,
+    },
+  });
+  return result;
+};

--- a/src/components/SearchClub/ClubCard.tsx
+++ b/src/components/SearchClub/ClubCard.tsx
@@ -14,6 +14,12 @@ export interface ClubCardProps {
   region: string;
   /** 동아리 썸네일 URL */
   logoUrl?: string;
+  /** 문의 링크 - 카카오톡 */
+  kakao?: string;
+  /** 문의 링크 - 인스타그램 */
+  insta?: string;
+  /** 현재 사용자 기준 이미 가입된 모임인지 여부 */
+  isMember?: boolean;
   /** 가입 신청 처리 함수 */
   onJoinRequest?: (clubId: number, message: string) => void;
 }
@@ -73,40 +79,17 @@ export default function ClubCard({
   participantTypes,
   region,
   logoUrl,
+  kakao,
+  insta,
+  isMember = false,
   onJoinRequest,
 }: ClubCardProps): React.ReactElement {
   const [mode, setMode] = useState<'default' | 'join' | 'inquiry'>('default');
   const [joinMessage, setJoinMessage] = useState('');
 
-  // 현재 사용자 닉네임 (실제로는 로그인된 사용자 정보에서 가져와야 함)
-  const currentUserNickname = 'dayoun'; // 임시로 하드코딩
-
-  // 더미 데이터: 이미 가입된 모임 목록 (API 명세서 참고)
-  const dummyClubMembers = [
-    {
-      clubMemberId: 1001,
-      nickname: 'dayoun', // 현재 사용자가 이미 가입된 모임
-      profileImgUrl: 'https://example.com/profile.jpg',
-      joinMessage: '책 너무 좋아요! 가입하고 싶어요.',
-      clubMemberStatus: 'PENDING'
-    },
-    {
-      clubMemberId: 1002,
-      nickname: 'reader123',
-      profileImgUrl: 'https://example.com/profile2.jpg',
-      joinMessage: '모임에 꼭 참여하고 싶습니다.',
-      clubMemberStatus: 'PENDING'
-    }
-  ];
-
-  // 현재 모임에 이미 가입되어 있는지 확인
-  const isAlreadyMember = dummyClubMembers.some(
-    member => member.nickname === currentUserNickname
-  );
-
   // 가입 신청 처리
   const handleJoinRequest = () => {
-    if (isAlreadyMember) {
+    if (isMember) {
       onJoinRequest?.(id, 'already_member');
       return;
     }
@@ -123,6 +106,15 @@ export default function ClubCard({
   };
 
   const handleJoinClick = () => setMode('join');
+  
+  // 기본 버튼 클릭 시: 이미 가입이면 상위에 알리고 종료, 아니면 가입 작성 모드로 전환
+  const onJoinButtonClick = () => {
+    if (isMember) {
+      onJoinRequest?.(id, 'already_member');
+      return;
+    }
+    handleJoinClick();
+  };
   const handleInquiryClick = () => setMode('inquiry');
 
   // 카테고리 ID를 이름으로 변환
@@ -204,7 +196,7 @@ export default function ClubCard({
           {/* 기본 모드 */}
           {mode === 'default' && (
             <ActionButtons
-              onJoinClick={handleJoinClick}
+              onJoinClick={onJoinButtonClick}
               onInquiryClick={handleInquiryClick}
             />
           )}
@@ -263,12 +255,20 @@ export default function ClubCard({
                 underline underline-offset-2
                 flex flex-col gap-[10px]
               ">
-                <a href="#">
-                  카카오톡 링크 카카오톡 링크
-                </a>
-                <a href="#">
-                  인스타 링크 인스타 링크
-                </a>
+                {kakao ? (
+                  <a href={kakao} target="_blank" rel="noopener noreferrer">
+                    카카오톡 링크 바로가기
+                  </a>
+                ) : (
+                  <span className="no-underline text-[#8D8D8D]">등록된 카카오톡 링크가 없습니다.</span>
+                )}
+                {insta ? (
+                  <a href={insta} target="_blank" rel="noopener noreferrer">
+                    인스타그램 링크 바로가기
+                  </a>
+                ) : (
+                  <span className="no-underline text-[#8D8D8D]">등록된 인스타그램 링크가 없습니다.</span>
+                )}
               </div>
             </>
           )}

--- a/src/hooks/useBookClubList.ts
+++ b/src/hooks/useBookClubList.ts
@@ -1,0 +1,16 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { fetchClubList } from '../apis/clubApi';
+import type { ClubListResult } from '../types/bookClub';
+import type { ClubSearchParams } from '../apis/clubApi';
+
+export function useBookClubList(params: Omit<ClubSearchParams, 'cursorId'>) {
+  return useInfiniteQuery<ClubListResult, Error>({
+    queryKey: ['clubList', params],
+    queryFn: ({ pageParam = null }) =>
+      fetchClubList({ ...params, cursorId: pageParam as number | null }),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor || null,
+  });
+}
+
+

--- a/src/hooks/useClubJoin.ts
+++ b/src/hooks/useClubJoin.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { requestJoinClub } from "../apis/clubApi";
+import type { JoinClubResult } from "../types/bookClub";
+
+type JoinVariables = { clubId: number; joinMessage: string };
+
+export const useClubJoin = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<JoinClubResult, Error, JoinVariables>({
+    mutationFn: ({ clubId, joinMessage }) =>
+      requestJoinClub(clubId, { joinMessage }),
+    onSuccess: (data) => {
+      // 가입 후 목록 최신화 (멤버 여부 등 갱신 목적)
+      queryClient.invalidateQueries({ queryKey: ["clubList"] });
+      if (data.open) {
+        alert("가입이 완료되었습니다.");
+      } else {
+        alert("가입 신청이 접수되었습니다. 운영진 승인 대기 중입니다.");
+      }
+    },
+    onError: (error: any) => {
+      const status: number | undefined = error?.response?.status;
+      if (status === 404) {
+        alert("존재하지 않는 독서모임입니다.");
+        return;
+      }
+      if (status === 409) {
+        alert("이미 가입을 신청했거나, 가입이 승인된 상태입니다.");
+        return;
+      }
+      alert("가입 신청에 실패했습니다. 다시 시도해주세요.");
+    },
+  });
+};
+
+

--- a/src/pages/Main/ClubSearchPage.tsx
+++ b/src/pages/Main/ClubSearchPage.tsx
@@ -7,6 +7,7 @@ import Header from '../../components/Header.tsx';
 import { useBookClubList } from '../../hooks/useBookClubList';
 import { useDebounce } from '../../hooks/useDebounce';
 import type { ClubListDto } from '../../types/bookClub';
+import { useClubJoin } from '../../hooks/useClubJoin';
 
 export default function ClubSearchPage(): React.ReactElement {
   const [query, setQuery] = useState('');
@@ -28,12 +29,19 @@ export default function ClubSearchPage(): React.ReactElement {
     [data]
   );
 
+  const { mutate: joinClub } = useClubJoin();
+
   // 가입 신청 처리
-  const handleJoinRequest = (_clubId: number, message: string) => {
+  const handleJoinRequest = (clubId: number, message: string) => {
     if (message === 'already_member') {
       setShowAlert(true);
       return;
     }
+    if (message === 'no_message') {
+      alert('가입 메시지를 작성해주세요.');
+      return;
+    }
+    joinClub({ clubId, joinMessage: message });
   };
 
   return (
@@ -73,7 +81,7 @@ export default function ClubSearchPage(): React.ReactElement {
                 독서모임 운영진이신가요?
               </span>
               <Link
-                to="/bookclub/apply"
+                to="/createClub"
                 className="
                   w-[105px] h-[32px]
                   bg-[#DED6CD] rounded-[16px]
@@ -99,7 +107,7 @@ export default function ClubSearchPage(): React.ReactElement {
               {status === 'pending' && (
                 <div className="py-8 text-sm text-gray-500">로딩 중...</div>
               )}
-              {status === 'success' && flatClubs.map(({ club }) => (
+              {status === 'success' && flatClubs.map(({ club, member }) => (
                 <div key={club.clubId} className='h-full'>
                   <ClubCard
                     id={club.clubId}
@@ -108,6 +116,9 @@ export default function ClubSearchPage(): React.ReactElement {
                     participantTypes={club.participantTypes}
                     region={club.region}
                     logoUrl={club.profileImageUrl}
+                    kakao={club.kakao}
+                    insta={club.insta}
+                    isMember={member}
                     onJoinRequest={handleJoinRequest}
                   />
                 </div>

--- a/src/pages/Main/ClubSearchPage.tsx
+++ b/src/pages/Main/ClubSearchPage.tsx
@@ -22,7 +22,7 @@ export default function ClubSearchPage(): React.ReactElement {
     size: 10,
   }), [debouncedKeyword]);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } = useBookClubList(requestParams);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status, error } = useBookClubList(requestParams);
 
   const flatClubs: ClubListDto[] = useMemo(
     () => data?.pages.flatMap(p => p.clubList) ?? [],
@@ -107,6 +107,12 @@ export default function ClubSearchPage(): React.ReactElement {
               {status === 'pending' && (
                 <div className="py-8 text-sm text-gray-500">로딩 중...</div>
               )}
+              {status === 'error' && (
+                <div className="py-8 text-sm text-red-500">
+                  데이터를 불러오는 중 오류가 발생했습니다.
+                  {error?.message && <p className="text-xs mt-2">{error.message}</p>}
+                </div>
+              )}
               {status === 'success' && flatClubs.map(({ club, member }) => (
                 <div key={club.clubId} className='h-full'>
                   <ClubCard
@@ -116,8 +122,6 @@ export default function ClubSearchPage(): React.ReactElement {
                     participantTypes={club.participantTypes}
                     region={club.region}
                     logoUrl={club.profileImageUrl}
-                    kakao={club.kakao}
-                    insta={club.insta}
                     isMember={member}
                     onJoinRequest={handleJoinRequest}
                   />

--- a/src/types/bookClub.ts
+++ b/src/types/bookClub.ts
@@ -54,7 +54,23 @@ export type ClubDto = {
   participantTypes: string[];
   insta?: string;
   kakao?: string;
+  staff?: boolean;
 };
+
+export type ClubListDto = {
+  club: ClubDto;
+  member: boolean;
+}
+
+export type ClubListResult = {
+  clubList: ClubListDto[];
+  hasNext: boolean;
+  nextCursor: number | null;
+  pageSize: number;
+}
 
 // 클럽 생성 응답 타입
 export type CreateClubResponse = ApiResponse<ClubDto>;
+
+// 클럽 목록 조회 응답 타입
+export type ClubSearchResponse = ApiResponse<ClubListResult>;

--- a/src/types/bookClub.ts
+++ b/src/types/bookClub.ts
@@ -74,3 +74,16 @@ export type CreateClubResponse = ApiResponse<ClubDto>;
 
 // 클럽 목록 조회 응답 타입
 export type ClubSearchResponse = ApiResponse<ClubListResult>;
+
+// 가입 신청 요청/응답 타입
+export type JoinClubRequest = {
+  joinMessage: string;
+};
+
+export type JoinClubResult = {
+  clubId: number;
+  clubName: string;
+  open: boolean; // 공개 모임 여부 (true면 즉시 가입)
+};
+
+export type JoinClubResponse = ApiResponse<JoinClubResult>;


### PR DESCRIPTION
# 제목 [feat] 북클럽 검색 페이지 API 연동

## 작업내용

1. 북클럽 목록 조회 및 검색 api 연동
2. 북클럽 가입 신청 api 연동

## 구현 사진
[독서모임 리스트 조회]
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/a2b75393-1642-42ab-ab43-3c92492e88d0" />

[무한 스크롤]
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/a9e3dc4b-54cb-4c44-ae00-6c82bd681164" />

[독서모임 검색]
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/e0d8b989-caba-412b-9d2d-fb099ff51461" />

[가입 신청 api 연동]
<img width="1920" height="1020" alt="모임 가입 신청 api 연동 사진" src="https://github.com/user-attachments/assets/0df1829a-1cb7-48ce-90ae-5f2fcc5500c1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 커서 기반 클럽 검색 API 연동 및 무한 페이징 지원
  - 클럽 가입 신청 기능 추가(신청 결과에 따른 안내 메시지)
  - 클럽 카드에 회원 여부 표시 및 가입 차단 로직 추가

- UI/UX
  - 카카오톡·인스타 계정이 있으면 클릭 가능한 링크로 표시, 없으면 회색 안내문구 표시
  - 로딩/빈 결과/추가 로딩 메시지 개선 및 스크롤 끝 자동 로드
  - 헤더 구성 간소화(알림·제목 중심) 및 신청 링크를 /createClub로 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->