### PR TITLE
[feat] 메인 홈- 공지사항, 책 이야기 api 연동

### DIFF
--- a/src/apis/BookStory/bookstories.ts
+++ b/src/apis/BookStory/bookstories.ts
@@ -1,0 +1,31 @@
+import type { BookStoryResponseDto } from "../../types/bookStories";
+import { axiosInstance } from "../axiosInstance";
+
+export type BookStoriesParams = {
+  scope: "ALL" | "FOLLOWING" | "MY" | "CLUB" | "TARGET";
+  clubId?: number;
+  targetMemberNickname?: string;
+  cursorId?: number | null;
+};
+
+export type BookStoriesResult = {
+  scopeInfo: any; // 필요한 타입으로 대체
+  memberClubList: any;
+  bookStoryResponses: BookStoryResponseDto[];
+  hasNext: boolean;
+  nextCursor: number;
+  pageSize: number;
+};
+
+// 책 이야기 전체 조회 API
+export const fetchBookStories = async (
+  params: BookStoriesParams
+): Promise<BookStoriesResult> => {
+  const result = await axiosInstance.get("/book-stories", {
+    params: {
+      ...params,
+      cursorId: params.cursorId ?? undefined,
+    },
+  });
+  return result;
+};

--- a/src/apis/BookStory/bookstories.ts
+++ b/src/apis/BookStory/bookstories.ts
@@ -1,4 +1,7 @@
-import type { BookStoryResponseDto } from "../../types/bookStories";
+import type {
+  BookStoryResponseDto,
+  BookStoriesResult,
+} from "../../types/bookStories";
 import { axiosInstance } from "../axiosInstance";
 
 export type BookStoriesParams = {
@@ -6,15 +9,6 @@ export type BookStoriesParams = {
   clubId?: number;
   targetMemberNickname?: string;
   cursorId?: number | null;
-};
-
-export type BookStoriesResult = {
-  scopeInfo: any; // 필요한 타입으로 대체
-  memberClubList: any;
-  bookStoryResponses: BookStoryResponseDto[];
-  hasNext: boolean;
-  nextCursor: number;
-  pageSize: number;
 };
 
 // 책 이야기 전체 조회 API

--- a/src/apis/notices.ts
+++ b/src/apis/notices.ts
@@ -1,19 +1,19 @@
 import type { NoticeResultDto } from "../types/notices";
 import { axiosInstance } from "./axiosInstance";
 
-interface FetchNoticesParams {
+export interface FetchNoticesParams {
   cursorId?: number | null;
   onlyImportant?: boolean;
 }
 
 export const fetchNotices = async (
-  params: FetchNoticesParams
+  params?: FetchNoticesParams
 ): Promise<NoticeResultDto> => {
-  const result = await axiosInstance.get("/clubs/notices", {
+  const { data } = await axiosInstance.get<NoticeResultDto>("/clubs/notices", {
     params: {
-      cursorId: params.cursorId ?? undefined,
-      onlyImportant: params.onlyImportant ?? false,
+      cursorId: params?.cursorId ?? undefined,
+      onlyImportant: params?.onlyImportant,
     },
   });
-  return result;
+  return data;
 };

--- a/src/apis/notices.ts
+++ b/src/apis/notices.ts
@@ -1,0 +1,19 @@
+import type { NoticeResultDto } from "../types/notices";
+import { axiosInstance } from "./axiosInstance";
+
+interface FetchNoticesParams {
+  cursorId?: number | null;
+  onlyImportant?: boolean;
+}
+
+export const fetchNotices = async (
+  params: FetchNoticesParams
+): Promise<NoticeResultDto> => {
+  const result = await axiosInstance.get("/clubs/notices", {
+    params: {
+      cursorId: params.cursorId ?? undefined,
+      onlyImportant: params.onlyImportant ?? false,
+    },
+  });
+  return result;
+};

--- a/src/components/Main/BookStoriesCard.tsx
+++ b/src/components/Main/BookStoriesCard.tsx
@@ -6,7 +6,7 @@ import reportIcon from "../../assets/icons/report.png";
 interface BookStoriesCardProps {
   title: string;
   story: string;
-  state: string;
+  state: "내 이야기" | "구독 중" | "구독하기";
   likes: number;
   authorNickname: string;
   authorProfileImageUrl?: string;
@@ -22,6 +22,14 @@ const BookStoriesCard = ({
   authorProfileImageUrl,
   bookCoverImageUrl,
 }: BookStoriesCardProps): React.ReactElement => {
+  // 상태별 버튼 스타일 클래스
+  const stateClass =
+    state === "내 이야기"
+      ? "text-white bg-[#4A5568]"
+      : state === "구독 중"
+      ? "text-white bg-[#A6917D]"
+      : "text-[#A6917D] border border-[#A6917D]";
+
   return (
     <div className="rounded-[16px] border-[2px] border-[#EAE5E2] overflow-hidden">
       <div className="flex flex-col gap-[10px] p-[28px] h-full">
@@ -31,13 +39,14 @@ const BookStoriesCard = ({
             <img
               src={bookCoverImageUrl ?? checker}
               alt={`${title} 책 표지`}
+              loading="lazy"
               className="w-full h-full object-cover"
             />
           </div>
 
           {/* 오른쪽 텍스트 영역 */}
           <div className="flex-1 flex flex-col justify-between">
-            {/* 상단: 프로필 + 구독 상태 */}
+            {/* 상단: 프로필 + 상태 */}
             <div className="flex justify-between items-center">
               <div className="flex items-center gap-[8px]">
                 {/* 프로필 이미지 */}
@@ -54,7 +63,9 @@ const BookStoriesCard = ({
                   {authorNickname}
                 </span>
               </div>
-              <span className="w-[60px] h-[24px] font-pretendard font-medium text-[12px] leading-[145%] text-white bg-[#A6917D] rounded-[15px] px-[20px] py-[2px] flex items-center justify-center whitespace-nowrap cursor-pointer">
+              <span
+                className={`w-[60px] h-[24px] font-pretendard font-medium text-[12px] leading-[145%] rounded-[15px] px-[20px] py-[2px] flex items-center justify-center whitespace-nowrap cursor-pointer ${stateClass}`}
+              >
                 {state}
               </span>
             </div>

--- a/src/components/Main/BookStoriesCard.tsx
+++ b/src/components/Main/BookStoriesCard.tsx
@@ -8,6 +8,9 @@ interface BookStoriesCardProps {
   story: string;
   state: string;
   likes: number;
+  authorNickname: string;
+  authorProfileImageUrl?: string;
+  bookCoverImageUrl?: string;
 }
 
 const BookStoriesCard = ({
@@ -15,16 +18,19 @@ const BookStoriesCard = ({
   story,
   state,
   likes,
+  authorNickname,
+  authorProfileImageUrl,
+  bookCoverImageUrl,
 }: BookStoriesCardProps): React.ReactElement => {
   return (
     <div className="rounded-[16px] border-[2px] border-[#EAE5E2] overflow-hidden">
       <div className="flex flex-col gap-[10px] p-[28px] h-full">
         <div className="flex gap-[20px] flex-1">
-          {/* 왼쪽 이미지 */}
-          <div className="w-[200px] h-[290px] object-cover bg-gray-100 rounded-lg overflow-hidden">
+          {/* 왼쪽 책 이미지 */}
+          <div className="w-[200px] h-[290px] bg-gray-100 rounded-lg overflow-hidden">
             <img
-              src={checker}
-              alt="book cover"
+              src={bookCoverImageUrl ?? checker}
+              alt={`${title} 책 표지`}
               className="w-full h-full object-cover"
             />
           </div>
@@ -34,9 +40,18 @@ const BookStoriesCard = ({
             {/* 상단: 프로필 + 구독 상태 */}
             <div className="flex justify-between items-center">
               <div className="flex items-center gap-[8px]">
-                <div className="w-[24px] h-[24px] bg-gray-300 rounded-full" />
+                {/* 프로필 이미지 */}
+                {authorProfileImageUrl ? (
+                  <img
+                    src={authorProfileImageUrl}
+                    alt={`${authorNickname} 프로필 이미지`}
+                    className="w-[24px] h-[24px] rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="w-[24px] h-[24px] bg-gray-300 rounded-full" />
+                )}
                 <span className="font-pretendard font-normal text-[12px] leading-[145%] text-[#000000]">
-                  hy
+                  {authorNickname}
                 </span>
               </div>
               <span className="w-[60px] h-[24px] font-pretendard font-medium text-[12px] leading-[145%] text-white bg-[#A6917D] rounded-[15px] px-[20px] py-[2px] flex items-center justify-center whitespace-nowrap cursor-pointer">

--- a/src/pages/Main/HomePage.tsx
+++ b/src/pages/Main/HomePage.tsx
@@ -1,74 +1,40 @@
+import React, { useEffect, useState } from "react";
 import NoticeCard from "../../components/Main/Notices/NoticeCard";
 import BookStoriesCard from "../../components/Main/BookStoriesCard";
 import Header from "../../components/Header";
 
-const notices = [
-  {
-    id: 1,
-    title: "북적북적",
-    date: "2025. 06. 12",
-    book: "넥서스",
-    type: "모임",
-    imageUrl: "https://placehold.co/262x232?text=Book1",
-    content: "내용내용내용내용내용내용내용내용",
-  },
-  {
-    id: 2,
-    title: "책방산책",
-    date: "2025. 07. 03",
-    book: "어린 왕자",
-    type: "투표",
-    imageUrl: "https://placehold.co/262x232?text=Book2",
-    content: "내용내용내용내용내용내용내용내용",
-  },
-  {
-    id: 3,
-    title: "책사모",
-    date: "2025. 10. 03",
-    book: "디어 에반 핸슨",
-    type: "공지",
-    imageUrl: "https://placehold.co/262x232?text=Book3",
-    content:
-      "내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용",
-  },
-] as const;
+import type { BookStoryResponseDto } from "../../types/bookStories";
+import { fetchBookStories } from "../../apis/BookStory/bookstories";
 
-const bookstories = [
-  {
-    id: 1,
-    title: "북적북적",
-    story:
-      "줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.",
-    state: "구독 중",
-    likes: 12,
-  },
-  {
-    id: 2,
-    title: "인간실격",
-    story:
-      "줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.",
-    state: "구독 중",
-    likes: 193,
-  },
-  {
-    id: 3,
-    title: "홍학의 자리",
-    story:
-      "줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.",
-    state: "구독 중",
-    likes: 2003,
-  },
-  {
-    id: 4,
-    title: "홍학의 자리",
-    story:
-      "줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.",
-    state: "구독 중",
-    likes: 2003,
-  },
-];
+import type { NoticeDto } from "../../types/notices";
+import { fetchNotices } from "../../apis/notices";
 
 export default function HomePage() {
+  const [bookStories, setBookStories] = useState<BookStoryResponseDto[]>([]);
+  const [notices, setNotices] = useState<NoticeDto[]>([]);
+  const [loadingBooks, setLoadingBooks] = useState(false);
+  const [loadingNotices, setLoadingNotices] = useState(false);
+  const [errorBooks, setErrorBooks] = useState<string | null>(null);
+  const [errorNotices, setErrorNotices] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoadingBooks(true);
+    fetchBookStories({ scope: "ALL" })
+      .then((data) => {
+        setBookStories(data.bookStoryResponses);
+      })
+      .catch((e) => setErrorBooks(e.message ?? "책 이야기 불러오기 실패"))
+      .finally(() => setLoadingBooks(false));
+
+    setLoadingNotices(true);
+    fetchNotices({ onlyImportant: false })
+      .then((data) => {
+        setNotices(data.noticeList);
+      })
+      .catch((e) => setErrorNotices(e.message ?? "공지사항 불러오기 실패"))
+      .finally(() => setLoadingNotices(false));
+  }, []);
+
   return (
     <div className="absolute left-[315px] right-[42px] opacity-100">
       {/* 헤더 */}
@@ -85,9 +51,27 @@ export default function HomePage() {
       <div className="overflow-y-auto h-[calc(100vh-80px)] w-full flex-1 pt-[30px] pl-[2px] pr-[30px] bg-[#FFFFFF]">
         {/* 공지사항 */}
         <div className="text-xl font-semibold text-gray-800 mb-4">공지사항</div>
+        {loadingNotices && <p>공지사항 로딩중...</p>}
+        {errorNotices && (
+          <p className="text-red-500">공지사항 에러: {errorNotices}</p>
+        )}
         <div className="flex gap-4 overflow-x-auto flex-nowrap scroll-smooth mb-12 scrollbar-hide">
           {notices.map((notice) => (
-            <NoticeCard key={notice.id} {...notice} />
+            <NoticeCard
+              key={notice.id}
+              title={notice.title}
+              date="날짜 정보 없음"
+              book="책 정보 없음"
+              type={
+                notice.tag === "모임" ||
+                notice.tag === "투표" ||
+                notice.tag === "공지"
+                  ? notice.tag
+                  : "공지"
+              }
+              imageUrl="https://placehold.co/262x232?text=공지"
+              content={notice.title}
+            />
           ))}
         </div>
 
@@ -95,10 +79,22 @@ export default function HomePage() {
         <div className="text-xl font-semibold text-gray-800 mb-4">
           책 이야기
         </div>
+        {loadingBooks && <p>책 이야기 로딩중...</p>}
+        {errorBooks && (
+          <p className="text-red-500">책 이야기 에러: {errorBooks}</p>
+        )}
         <div className="flex gap-4 overflow-x-auto flex-nowrap scroll-smooth scrollbar-hide">
-          {bookstories.map((story) => (
-            <div key={story.id} className="flex-shrink-0 w-[33rem]">
-              <BookStoriesCard {...story} />
+          {bookStories.map((story) => (
+            <div key={story.bookStoryId} className="flex-shrink-0 w-[33rem]">
+              <BookStoriesCard
+                title={story.bookStoryTitle}
+                story={story.description}
+                state={story.writtenByMe ? "내 이야기" : "구독 중"}
+                likes={story.likes}
+                authorNickname={story.authorInfo.nickname}
+                authorProfileImageUrl={story.authorInfo.profileImageUrl}
+                bookCoverImageUrl={story.bookInfo.profileImageUrl}
+              />
             </div>
           ))}
         </div>

--- a/src/pages/Main/HomePage.tsx
+++ b/src/pages/Main/HomePage.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
     setLoadingBooks(true);
     fetchBookStories({ scope: "ALL" })
       .then((data) => {
-        setBookStories(data.bookStoryResponses);
+        setBookStories(data?.bookStoryResponses ?? []);
       })
       .catch((e) => setErrorBooks(e.message ?? "책 이야기 불러오기 실패"))
       .finally(() => setLoadingBooks(false));
@@ -29,7 +29,7 @@ export default function HomePage() {
     setLoadingNotices(true);
     fetchNotices({ onlyImportant: false })
       .then((data) => {
-        setNotices(data.noticeList);
+        setNotices(data?.noticeList ?? []);
       })
       .catch((e) => setErrorNotices(e.message ?? "공지사항 불러오기 실패"))
       .finally(() => setLoadingNotices(false));
@@ -84,19 +84,28 @@ export default function HomePage() {
           <p className="text-red-500">책 이야기 에러: {errorBooks}</p>
         )}
         <div className="flex gap-4 overflow-x-auto flex-nowrap scroll-smooth scrollbar-hide">
-          {bookStories.map((story) => (
-            <div key={story.bookStoryId} className="flex-shrink-0 w-[33rem]">
-              <BookStoriesCard
-                title={story.bookStoryTitle}
-                story={story.description}
-                state={story.writtenByMe ? "내 이야기" : "구독 중"}
-                likes={story.likes}
-                authorNickname={story.authorInfo.nickname}
-                authorProfileImageUrl={story.authorInfo.profileImageUrl}
-                bookCoverImageUrl={story.bookInfo.profileImageUrl}
-              />
-            </div>
-          ))}
+          {bookStories.map((story) => {
+            const state: "내 이야기" | "구독 중" | "구독하기" =
+              story.writtenByMe
+                ? "내 이야기"
+                : story.authorInfo.following
+                ? "구독 중"
+                : "구독하기";
+
+            return (
+              <div key={story.bookStoryId} className="flex-shrink-0 w-[33rem]">
+                <BookStoriesCard
+                  title={story.bookStoryTitle}
+                  story={story.description}
+                  state={state}
+                  likes={story.likes}
+                  authorNickname={story.authorInfo.nickname}
+                  authorProfileImageUrl={story.authorInfo.profileImageUrl}
+                  bookCoverImageUrl={story.bookInfo.profileImageUrl}
+                />
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/types/bookStories.ts
+++ b/src/types/bookStories.ts
@@ -1,0 +1,46 @@
+export interface BookInfoDto {
+  nickname: string;
+  profileImageUrl: string;
+}
+
+export interface AuthorInfoDto {
+  nickname: string;
+  profileImageUrl: string;
+  following: boolean;
+}
+
+export interface BookStoryResponseDto {
+  bookStoryId: number;
+  bookInfo: BookInfoDto;
+  authorInfo: AuthorInfoDto;
+  bookStoryTitle: string;
+  description: string;
+  likes: number;
+  likedByMe: boolean;
+  createdAt: string;
+  writtenByMe: boolean;
+}
+
+export interface ScopeInfoDto {
+  scope: string;
+  selectedClub: {
+    clubId: number;
+    clubName: string;
+  };
+}
+
+export interface MemberClubListDto {
+  clubList: {
+    clubId: number;
+    clubName: string;
+  }[];
+}
+
+export interface BookStoriesResult {
+  scopeInfo: ScopeInfoDto;
+  memberClubList: MemberClubListDto;
+  bookStoryResponses: BookStoryResponseDto[];
+  hasNext: boolean;
+  nextCursor: number;
+  pageSize: number;
+}

--- a/src/types/notices.ts
+++ b/src/types/notices.ts
@@ -1,0 +1,14 @@
+export interface NoticeDto {
+  id: number;
+  tag: "모임" | "투표" | "공지" | string;
+  title: string;
+  important: boolean;
+}
+
+export interface NoticeResultDto {
+  noticeList: NoticeDto[];
+  hasNext: boolean;
+  nextCursor: number;
+  pageSize: number;
+  staff: boolean;
+}


### PR DESCRIPTION
<img width="2324" height="1434" alt="image" src="https://github.com/user-attachments/assets/c8bab39b-5b53-4b43-aeb7-05244d08631a" />
<img width="810" height="114" alt="image" src="https://github.com/user-attachments/assets/6a6e8656-3932-43df-a6b6-9502f68eb4cf" />

- [x] 메인 공지사항 api 연동
- [x] 메인 책이야기 api 연동

공지사항이 없는 상태에서 연동을 진행했기 때문에 추후에 공지 넣고 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 홈 화면이 실제 API 데이터를 사용해 공지와 책 이야기를 불러옵니다.
  * 로딩·오류 상태 메시지로 데이터 수신 상황을 안내합니다.
  * 책 이야기 카드에 작가 닉네임·프로필·책 표지(지연 로딩 포함)와 상태 배지가 추가되었습니다.
  * 공지 카드가 유형 표시와 기본 이미지 처리를 지원하며 실제 공지 데이터를 표시합니다.
  * 좋아요 수·작성자 여부 등 최신 정보가 UI에 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->