### PR TITLE
[feat] 헤더 API 연동

### DIFF
--- a/src/apis/My/memberApi.ts
+++ b/src/apis/My/memberApi.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from "../axiosInstance";
+import type {
+  UpdateMyProfileRequest,
+  UpdateMyProfileResult,
+  MyProfile,
+} from "../../types/My/member";
+
+/** 내 프로필 조회 (이미 있다면 기존 함수 사용해도 됨) */
+export async function getMyProfile(): Promise<MyProfile> {
+  return axiosInstance.get("/members/me");
+}
+
+/** 내 프로필 수정: PATCH /api/members/me */
+export async function patchMyProfile(
+  payload: UpdateMyProfileRequest
+): Promise<UpdateMyProfileResult> {
+  return axiosInstance.patch("/members/me", payload);
+}

--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -53,6 +53,12 @@ export async function postAdditionalInfo(
   return res; // {}
 }
 
+// 로그아웃 
+export async function postLogout(): Promise<void> {
+  // axiosInstance는 {isSuccess, result}에서 result만 돌려주도록 인터셉터가 잡혀있음
+  await axiosInstance.post("/auth/logout");
+}
+
 // 공개 API (쿠키 불필요) 
 
 // 닉네임 중복 확인 — POST + query, 비로그인 호출

--- a/src/apis/headerApi.ts
+++ b/src/apis/headerApi.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from "./axiosInstance";
+import type { MyProfileResult, NotificationPreviewResult } from "../types/header";
+
+function asResult<T>(data: any): T {
+  if (data && typeof data === "object" && "result" in data) {
+    return data.result as T;           // 서버가 Envelope로 보낸 경우
+  }
+  return data as T;                    // 이미 언래핑된 경우
+}
+
+export async function getMyProfile(): Promise<MyProfileResult> {
+  const { data } = await axiosInstance.get("/members/me");
+  return asResult<MyProfileResult>(data);
+}
+
+export async function getNotificationPreview(size = 5): Promise<NotificationPreviewResult> {
+  const { data } = await axiosInstance.get("/notifications/preview", { params: { size } });
+  return asResult<NotificationPreviewResult>(data);
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,92 +1,124 @@
 import { useState, useEffect, useRef } from "react";
 import { FaBell } from "react-icons/fa";
-import { useNavigate } from "react-router-dom"; 
+import { useNavigate } from "react-router-dom";
 import { FaCircleCheck } from "react-icons/fa6";
-
-type Notification = {
-  message: string;
-  time: string;
-};
-
-type UserProfile = {
-  username: string;
-  bio: string;
-};
+import { useQuery } from "@tanstack/react-query";
+import { getMyProfile, getNotificationPreview } from "../apis/headerApi";
 
 interface HeaderProps {
   pageTitle: string;
-  userProfile?: UserProfile;
-  notifications?: Notification[];
-  customClassName?: string;        // 커스텀으로 각자 페이지에서 조정 가능
-  isAdmin?: boolean;    // 운영자 여부 prop 추가
+  customClassName?: string;
+  isAdmin?: boolean;
+  // 운영진에게만 노출할 ‘조 관리하기’ 버튼을 이 페이지에서 보여줄지 여부
+  showManageButton?: boolean;
+  // 버튼 라벨 커스텀 (조 관리하기)
+  manageLabel?: string;
+  // 클릭 시 이동할 경로 (기본: '/club/manage'), onClickManage가 있으면 무시
+  manageTo?: string;
+  // 클릭 핸들러를 직접 넘기고 싶을 때 
+  onClickManage?: () => void;
 }
 
-// 기본 더미 데이터
-const defaultUserProfile: UserProfile = {
-  username: "hy_0716",
-  bio: "책을 아는가? 나는 모른다",
+const TYPE_TEXT: Record<string, string> = {
+  LIKE: "좋아요를 눌렀습니다.",
+  COMMENT: "댓글을 남겼습니다.",
+  FOLLOW: "팔로우했습니다.",
 };
 
-const defaultNotifications: Notification[] = [
-  { message: "새 댓글이 달렸습니다.", time: "2025-07-11 13:00" },
-  { message: "이현서님이 팔로우했습니다.", time: "2025-07-11 12:45" },
-  { message: "새 모임이 등록되었습니다.", time: "2025-07-10 18:30" },
-  { message: "공지사항이 업데이트되었습니다.", time: "2025-07-09 09:15" },
-  { message: "투표가 시작되었습니다.", time: "2025-07-08 14:20" },
-];
+const Header = ({
+  pageTitle,
+  customClassName,
+  isAdmin = false,
+  showManageButton = false,
+  manageLabel = "조 관리하기",
+  manageTo = "/club/manage",
+  onClickManage,
+}: HeaderProps) => {
+  const navigate = useNavigate();
 
-const Header = (props: HeaderProps) => {
-  const {
-    pageTitle,
-    userProfile = defaultUserProfile,
-    notifications = defaultNotifications,
-    customClassName,
-    isAdmin = false, // 운영자인 경우 true로 쓰면 됨
-  } = props;
+  // 프로필
+  const { data: me, isPending: profilePending } = useQuery({
+    queryKey: ["header", "me"],
+    queryFn: getMyProfile,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: true,
+    retry: 0,
+  });
+
+  // 알림 프리뷰
+  const { data: preview, isPending: notiPending } = useQuery({
+    queryKey: ["header", "preview", 5],
+    queryFn: () => getNotificationPreview(5),
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
+    retry: 0,
+  });
+
+  const notificationsToShow =
+    (preview?.notifications ?? []).slice(0, 5).map((n) => ({
+      message: `${n.senderNickname}님이 ${TYPE_TEXT[n.notificationType] ?? n.notificationType}`,
+      time: new Date(n.createdAt).toLocaleString(),
+      redirectPath: n.redirectPath,
+    }));
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
-  const navigate = useNavigate(); 
-
-  const toggleModal = () => setIsModalOpen((prev) => !prev);
-
-  const handleClickOutside = (e: MouseEvent) => {
-    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-      setIsModalOpen(false);
-    }
-  };
 
   useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        setIsModalOpen(false);
+      }
+    };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const goToMyPage = () => {
-    navigate("/mypage"); 
+  const unreadCount = notificationsToShow.length;
+
+  const goManage = () => {
+    if (onClickManage) onClickManage();
+    else navigate(manageTo);
   };
 
   return (
     <header
       className={`${
-        customClassName
-          ? customClassName
-          : "fixed left-[264px] right-0 top-3 h-[56px] lg:px-13 px-4 md:px-8 " // 기본값
-      } bg-white flex justify-between items-center z-50 `}
+        customClassName ?? "fixed left-[264px] right-0 top-3 h-[56px] lg:px-13 px-4 md:px-8 "
+      } bg-white flex justify-between items-center z-50`}
     >
-      {/* 페이지 타이틀 */}
-      <h1 className="font-bold text-lg md:text-xl lg:text-2xl text-[#2C2C2C]">
-        {pageTitle}
-      </h1>
+      {/* 타이틀 + (운영진 전용) 조 관리하기 */}
+      <div className="flex items-center gap-3">
+        <h1 className="font-bold text-lg md:text-xl lg:text-2xl text-[#2C2C2C]">
+          {pageTitle}
+        </h1>
 
-      {/* 알림 + 프로필 */}
+        {/* 운영진이면서 이 페이지에서만 노출 */}
+        {isAdmin && showManageButton && (
+          <button
+            type="button"
+            onClick={goManage}
+            className="text-sm md:text-base text-[#8D8D8D] hover:text-[#2C2C2C] underline underline-offset-2 decoration-[#C4E8B2]"
+          >
+            {manageLabel}
+          </button>
+        )}
+      </div>
+
       <div className="flex items-center gap-3 md:gap-4 relative">
-        {/* 종 아이콘 */}
+        {/* 종 아이콘 + 배지 */}
         <button
-          onClick={toggleModal}
+          onClick={() => setIsModalOpen((p) => !p)}
           aria-label="Notifications"
-          className="w-8 h-8 flex justify-center items-center shrink-0"
+          className="relative w-8 h-8 flex justify-center items-center shrink-0"
+          disabled={notiPending}
         >
           <FaBell size={32} color="#90D26D" />
+          {!notiPending && unreadCount > 0 && (
+            <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-[4px] rounded-full text-[11px] bg-[#90D26D] text-white flex items-center justify-center">
+              {unreadCount}
+            </span>
+          )}
         </button>
 
         {/* 알림 모달 */}
@@ -95,44 +127,48 @@ const Header = (props: HeaderProps) => {
             ref={modalRef}
             className="absolute right-0 top-[60px] w-[300px] bg-white border-2 border-[#C4E8B2] rounded-[16px] shadow-lg p-[20px] z-50"
           >
-            <ul className="space-y-2">
-              {notifications.slice(0, 5).map((notif, index) => (
-                <li
-                  key={index}
-                  className="flex justify-between items-center px-[10px] py-[8px] hover:bg-[#F1F8EF] rounded-[12px]"
-                >
-                  <div className="flex flex-col">
-                    <span className="text-[#2C2C2C] text-[14px] font-medium leading-[145%]">
-                      {notif.message}
-                    </span>
-                    <span className="text-[#8D8D8D] text-[12px] font-normal leading-[145%]">
-                      {notif.time}
-                    </span>
-                  </div>
-                  <div className="w-[15px] h-[15px] bg-[#90D26D] rounded-full flex-shrink-0" />
-                </li>
-              ))}
-            </ul>
+            {notiPending ? (
+              <div className="text-sm text-[#8D8D8D]">알림 불러오는 중...</div>
+            ) : notificationsToShow.length === 0 ? (
+              <div className="text-sm text-[#8D8D8D]">알림이 존재하지 않습니다.</div>
+            ) : (
+              <ul className="space-y-2">
+                {notificationsToShow.map((n, i) => (
+                  <li
+                    key={i}
+                    className="flex justify-between items-center px-[10px] py-[8px] hover:bg-[#F1F8EF] rounded-[12px]"
+                  >
+                    <div className="flex flex-col">
+                      <span className="text-[#2C2C2C] text-[14px] font-medium leading-[145%]">
+                        {n.message}
+                      </span>
+                      <span className="text-[#8D8D8D] text-[12px] font-normal leading-[145%]">
+                        {n.time}
+                      </span>
+                    </div>
+                    <div className="w-[15px] h-[15px] bg-[#90D26D] rounded-full flex-shrink-0" />
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         )}
 
         {/* 프로필 */}
         <div
-          onClick={goToMyPage}
+          onClick={() => navigate("/mypage/myprofile")}
           className="flex gap-2 md:gap-3 items-center min-w-0 cursor-pointer"
         >
           <div className="w-10 h-10 bg-gray-300 rounded-full shrink-0" />
           <div className="flex flex-col justify-center min-w-0">
             <div className="flex items-center gap-3">
               <span className="text-sm md:text-base font-semibold text-[#2C2C2C] truncate">
-                {userProfile.username}
+                {me?.nickname || (profilePending ? "불러오는 중..." : "")}
               </span>
-              {isAdmin && (
-                <FaCircleCheck size={16} color="#90D26D" /> // 운영자일 때만 체크표시
-              )}
+              {isAdmin && <FaCircleCheck size={16} color="#90D26D" />}
             </div>
             <span className="text-xs md:text-sm text-[#8D8D8D] truncate">
-              {userProfile.bio}
+              {me?.description ?? ""}
             </span>
           </div>
         </div>

--- a/src/components/MyPageHeader.tsx
+++ b/src/components/MyPageHeader.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import AlertModal from "./AlertModal";
+import { useLogout } from "../hooks/useAuth"; 
 
 type MyPageHeaderProps = {
   title: string;
@@ -11,13 +12,25 @@ const MyPageHeader = (props: MyPageHeaderProps) => {
   const navigate = useNavigate();
   const [showLogoutModal, setShowLogoutModal] = useState(false);
 
+  // 로그아웃 훅
+  const { mutate: logout, isPending } = useLogout();
+
   const handleLogout = () => {
     setShowLogoutModal(true);
   };
 
   const handleConfirmLogout = () => {
-    setShowLogoutModal(false);
-    navigate("/");
+
+    logout(undefined, {
+      onSuccess: () => {
+        setShowLogoutModal(false);
+        navigate("/"); 
+      },
+      onError: (e) => {
+        setShowLogoutModal(false);
+        alert(e?.message || "로그아웃에 실패했습니다.");
+      },
+    });
   };
 
   return (
@@ -33,10 +46,11 @@ const MyPageHeader = (props: MyPageHeaderProps) => {
           </button>
           <span className="text-[#90D26D]">|</span>
           <button
-            className="text-[#2C2C2C] hover:text-[#90D26D] cursor-pointer"
+            className="text-[#2C2C2C] hover:text-[#90D26D] cursor-pointer disabled:opacity-60"
             onClick={handleLogout}
+            disabled={isPending} 
           >
-            로그아웃
+            {isPending ? "로그아웃 중..." : "로그아웃"}
           </button>
         </div>
       </header>

--- a/src/hooks/My/useMember.ts
+++ b/src/hooks/My/useMember.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getMyProfile, patchMyProfile } from "../../apis/My/memberApi";
+import type { MyProfile, UpdateMyProfileRequest, UpdateMyProfileResult } from "../../types/My/member";
+import { QK } from "../useHeader"; 
+
+export const useMyProfileQuery = () =>
+  useQuery<MyProfile, Error>({
+    queryKey: QK.me,
+    queryFn: getMyProfile,
+  });
+
+export const useUpdateMyProfile = () => {
+  const qc = useQueryClient();
+  return useMutation<UpdateMyProfileResult, Error, UpdateMyProfileRequest>({
+    mutationFn: (payload) => patchMyProfile(payload),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: QK.me }); // 헤더/프로필 즉시 반영
+    },
+  });
+};

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -1,0 +1,68 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyProfile, getNotificationPreview } from "../apis/headerApi";
+import type {
+  MyProfileResult,
+  NotificationPreviewResult,
+  HeaderUserProfile,
+  HeaderNotification,
+} from "../types/header";
+
+const TYPE_TEXT: Record<string, string> = {
+  LIKE: "좋아요를 눌렀습니다.",
+  COMMENT: "댓글을 남겼습니다.",
+  FOLLOW: "팔로우했습니다.",
+};
+
+export const QK = {
+  me: ["header", "me"] as const,
+  notiPreview: (size = 5) => ["header", "preview", size] as const,
+};
+
+export const useHeaderData = () => {
+  // 제네릭: <TQueryFnData, TError, TData>
+  const {
+    data: profile,
+    isLoading: profileLoading,
+    error: profileError,
+  } = useQuery<MyProfileResult, Error, HeaderUserProfile>({
+    queryKey: QK.me,
+    queryFn: getMyProfile, // Promise<MyProfileResult>
+    refetchOnMount: "always",
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
+    select: (d) => ({
+      username: d.nickname ?? "",
+      bio: d.description ?? "",
+      imgUrl: d.profileImageUrl,
+    }),
+  });
+
+  const {
+    data: notifications,
+    isLoading: notiLoading,
+    error: notiError,
+  } = useQuery<NotificationPreviewResult, Error, HeaderNotification[]>({
+    queryKey: QK.notiPreview(5),
+    queryFn: () => getNotificationPreview(5), // Promise<NotificationPreviewResult>
+    refetchOnMount: "always",
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
+    select: (res) =>
+      (res.notifications ?? []).map((n) => ({
+        message: `${n.senderNickname}님이 ${TYPE_TEXT[n.notificationType] ?? n.notificationType}`,
+        time: new Date(n.createdAt).toLocaleString(),
+        redirectPath: n.redirectPath,
+      })),
+  });
+
+  return {
+    profile,
+    profileLoading,
+    profileError,
+    notifications,
+    notiLoading,
+    notiError,
+  };
+};

--- a/src/types/My/member.ts
+++ b/src/types/My/member.ts
@@ -1,0 +1,18 @@
+export type Category = { id: number; name: string };
+
+export type MyProfile = {
+  nickname: string;
+  description: string | null;
+  profileImageUrl: string | null;
+  categories: Category[];
+};
+
+// PATCH /members/me 요청
+export type UpdateMyProfileRequest = {
+  description?: string | null;
+  imgUrl?: string | null;        // 프로필 이미지 URL(선택)
+  categoryIds?: number[];        // 선택 카테고리 ID 목록
+};
+
+// 응답은 갱신된 내 프로필
+export type UpdateMyProfileResult = MyProfile;

--- a/src/types/header.ts
+++ b/src/types/header.ts
@@ -1,0 +1,31 @@
+export type NotificationPreviewItem = {
+  notificationId: number;
+  notificationType: string; 
+  senderNickname: string;
+  read: boolean;
+  createdAt: string;   
+  redirectPath: string;
+};
+export type NotificationPreviewResult = {
+  notifications: NotificationPreviewItem[];
+};
+
+export type MyProfileResult = {
+  nickname: string;
+  description: string;
+  profileImageUrl: string;
+  categories?: { id: number; name: string }[];
+};
+
+// UI용 뷰모델
+export type HeaderUserProfile = {
+  username: string;
+  bio: string;
+  imgUrl?: string;
+};
+
+export type HeaderNotification = {
+  message: string;
+  time: string;
+  redirectPath?: string;
+};


### PR DESCRIPTION
헤더 API 연결

-  내 프로필 조회 API 연결
-  읽지 않은 알림 5개 조회 API 연결
-  마이페이지헤더-내 프로필 편집 API 연결
-  로그아웃 API 연결
-  헤더에 독서모임 조 관리하기 버튼 넣기
-  마이프로필페이지- presigned url API 연결
-  마이프로필편집에서 닉네임 및 한줄소개 수정 시 헤더에 반영

** 로그인 하고 정보를 바로 헤더에 반영하려고 하는데 response는 오는데 헤더에 반영이 안되어서 추후 수정 예정..

<마이 프로필 편집하고 바로 헤더로 연결>
<img width="1919" height="931" alt="image" src="https://github.com/user-attachments/assets/23326a72-e655-4ccd-8481-e853604f908d" />
<img width="1919" height="945" alt="image" src="https://github.com/user-attachments/assets/88594596-2654-41ec-b693-8877e732aa11" />
<img width="1919" height="943" alt="image" src="https://github.com/user-attachments/assets/448326e8-8b81-4eb2-8167-12eb76b124e0" />
<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/d75f2392-abb9-4de3-ae11-9c86a09be4c7" />

<로그인 정보는 응답으로 오지만 헤더에 반영안됨-추후 수정 예정>
<img width="1919" height="961" alt="image" src="https://github.com/user-attachments/assets/24adc1b8-fb22-48ca-b161-0344ae8fcc33" />
<img width="1919" height="949" alt="image" src="https://github.com/user-attachments/assets/081c2264-afad-461b-8e26-658f05d19b3e" />

<로그아웃>
<img width="1919" height="969" alt="image" src="https://github.com/user-attachments/assets/2b17557e-a508-4199-9c71-3c4252438c5e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 헤더가 내 프로필과 알림 미리보기를 동적으로 로드하고, 읽지 수 배지와 모달(로딩/빈 상태 포함)을 제공합니다.
  - 헤더에 관리 버튼을 추가하고 표시 여부, 라벨, 이동 경로, 클릭 동작을 커스터마이즈할 수 있습니다.
  - 내 프로필 페이지에서 서버 연동으로 프로필 조회/수정(소개, 이미지, 관심 카테고리)이 가능합니다.

- UX 개선
  - 프로필/알림 데이터 자동 새로고침, 로딩·저장 중 버튼 비활성화 및 상태 표시.
  - 로그아웃 진행 상태 표시, 오류 안내, 성공 시 홈으로 이동.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->