### PR TITLE
[feat] 독서모임(북클럽) 홈화면 - 공지사항 API 연동

### DIFF
--- a/src/apis/clubAnnouncements/clubNoticeApi.ts
+++ b/src/apis/clubAnnouncements/clubNoticeApi.ts
@@ -13,7 +13,7 @@ export const getClubNotices = async (
       size: Math.min(size, 10) // 최대 10개로 제한
     };
 
-    if (cursorId) {
+    if (cursorId != null) {
       params.cursorId = cursorId;
     }
 

--- a/src/apis/clubAnnouncements/clubNoticeApi.ts
+++ b/src/apis/clubAnnouncements/clubNoticeApi.ts
@@ -1,0 +1,29 @@
+import type { noticeListResult } from '../../types/clubNotice';
+import { axiosInstance } from '../axiosInstance';
+
+export const getClubNotices = async (
+  clubId: number,
+  onlyImportant: boolean = true,
+  cursorId?: number,
+  size: number = 5
+): Promise<noticeListResult> => {
+  try {
+    const params: Record<string, any> = {
+      onlyImportant,
+      size: Math.min(size, 10) // 최대 10개로 제한
+    };
+
+    if (cursorId) {
+      params.cursorId = cursorId;
+    }
+
+    const response = await axiosInstance.get<noticeListResult>(
+      `/clubs/${clubId}/notices`,
+      { params }
+    );
+    return response as unknown as noticeListResult;
+  } catch (error) {
+    console.error('공지사항 조회 실패:', error);
+    throw error;
+  }
+};

--- a/src/components/BookClub/AnnouncementCard.tsx
+++ b/src/components/BookClub/AnnouncementCard.tsx
@@ -160,10 +160,10 @@ function AnnouncementCardItem({
               <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-2" />
             </div>
             <div 
-              className="w-[269px] h-[207px] mt-[26px] border-[2px] border-[#EAE5E2] rounded-[16px]"
+              className="relative w-[269px] h-[207px] mt-[26px] border-[2px] border-[#EAE5E2] rounded-[16px]"
             >
               <div className = "mt-[14.5px] pointer-events-none" aria-hidden="true">
-                {item.voteOptions?.map((option: VoteOption) => (
+                {item.voteOptions?.slice(0, 3).map((option: VoteOption) => (
                   <label 
                     key={option.value} 
                     className="
@@ -172,11 +172,8 @@ function AnnouncementCardItem({
                       w-[224px] h-[46px]
                       cursor-pointer
                       border-b-2 border-[#EAE5E2]
-                      font-pretendard
                       font-medium
                       text-[14px]
-                      leading-[145%]
-                      tracking-[-0.1%]
                       text-[#434343]
                     "
                   >
@@ -195,18 +192,16 @@ function AnnouncementCardItem({
               ))}
               <div
                 className="
-                  ml-[177.5px] mt-[16px]
+                  absolute
+                  right-[22.5px] bottom-[16px]
                   w-[69px] h-[24px]
                   bg-[#FF8045] 
                   text-white 
                   rounded-[15px]
-                  font-pretendard
                   font-semibold
-                  text-[12px]
-                  leading-[145%]
-                  tracking-[-0.1%]                 
+                  text-[12px]               
                   whitespace-nowrap
-                  cursor-pointer
+                  flex items-center justify-center
                 "
               >
                 투표하기

--- a/src/components/BookClub/AnnouncementCard.tsx
+++ b/src/components/BookClub/AnnouncementCard.tsx
@@ -1,10 +1,10 @@
 // src/components/BookClub/AnnouncementCard.tsx
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate, useParams, type Params } from 'react-router-dom';
 import type { AnnouncementProps, VoteOption } from '../../types/announcement';
 import vector from '../../assets/images/vector.png';
 import arrow from '../../assets/images/shortcutArrow.png';
-
+ 
 export default function AnnouncementCard({
   items,
 }: {
@@ -26,14 +26,8 @@ function AnnouncementCardItem({
 }: {
   item: AnnouncementProps;
 }): React.ReactElement {
-  const [selectedVote, setSelectedVote] = useState<string>('');
   const navigate = useNavigate();
   const { bookclubId } = useParams<Params>();
-  const handleVoteSubmit = () => {
-    if (selectedVote && item.onVoteSubmit) {
-      item.onVoteSubmit(selectedVote);
-    }
-  };
 
   const handleCardClick = () => {
     const itemId = item.id || 1;
@@ -68,6 +62,7 @@ function AnnouncementCardItem({
         flex flex-col                       
         overflow-hidden
         cursor-pointer
+        select-none
         hover:bg-gray-50
         transition-colors"
     >
@@ -165,10 +160,9 @@ function AnnouncementCardItem({
               <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-2" />
             </div>
             <div 
-              onClick={(e) => e.stopPropagation()}
               className="w-[269px] h-[207px] mt-[26px] border-[2px] border-[#EAE5E2] rounded-[16px]"
             >
-              <form className = "mt-[14.5px]">
+              <div className = "mt-[14.5px] pointer-events-none" aria-hidden="true">
                 {item.voteOptions?.map((option: VoteOption) => (
                   <label 
                     key={option.value} 
@@ -186,31 +180,20 @@ function AnnouncementCardItem({
                       text-[#434343]
                     "
                   >
-                  <input
-                    type="radio"
-                    name="vote"
-                    value={option.value}
-                    checked={selectedVote === option.value}
-                    onChange={(e) => setSelectedVote(e.target.value)}
+                  <span
+                    aria-hidden="true"
                     className="
                       w-[24px] h-[24px]
                       border-2 border-[#BBBBBB]
                       rounded-full
-                      appearance-none
-                      cursor-pointer
                       mr-2
-                      checked:bg-[#FF8045]
                       bg-white
-                      transition-all duration-200
                     "
                   />
                   <span className="ml-[12px]">{option.label}</span>
                 </label>
               ))}
-              <button
-                type="button"
-                onClick={handleVoteSubmit}
-                disabled={!selectedVote}
+              <div
                 className="
                   ml-[177.5px] mt-[16px]
                   w-[69px] h-[24px]
@@ -227,8 +210,8 @@ function AnnouncementCardItem({
                 "
               >
                 투표하기
-              </button>
-            </form>
+              </div>
+            </div>
           </div>
         </div>
         )}

--- a/src/components/BookClub/AnnouncementCard.tsx
+++ b/src/components/BookClub/AnnouncementCard.tsx
@@ -1,14 +1,13 @@
-// src/components/BookClub/AnnouncementCard.tsx
 import React from 'react';
-import { useNavigate, useParams, type Params } from 'react-router-dom';
-import type { AnnouncementProps, VoteOption } from '../../types/announcement';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { noticeListItemDto, voteItemDto } from '../../types/clubNotice';
 import vector from '../../assets/images/vector.png';
 import arrow from '../../assets/images/shortcutArrow.png';
  
 export default function AnnouncementCard({
   items,
 }: {
-  items: AnnouncementProps[];
+  items: noticeListItemDto[];
 }): React.ReactElement {
   return (
     <div className="overflow-x-auto">
@@ -24,205 +23,101 @@ export default function AnnouncementCard({
 function AnnouncementCardItem({
   item,
 }: {
-  item: AnnouncementProps;
+  item: noticeListItemDto;
 }): React.ReactElement {
   const navigate = useNavigate();
-  const { bookclubId } = useParams<Params>();
+  type RouteParams = { bookclubId?: string };
+  const { bookclubId } = useParams<RouteParams>();
 
   const handleCardClick = () => {
     const itemId = item.id || 1;
-    switch (item.tag) { 
-      case '모임':
-        const meetingId = itemId;
-        navigate(`/bookclub/${bookclubId}/notices/${meetingId}`);
-        break;
-      case '투표':
-        const voteId = itemId;
-        navigate(`/bookclub/${bookclubId}/notices/${voteId}`);
-        break;
-      case '공지':
-        const generalId = itemId;
-        navigate(`/bookclub/${bookclubId}/notices/${generalId}`);
-        break;
-      default:
-        break;
+    if (item.tag === '모임') {
+      navigate(`/bookclub/${bookclubId}/notices/${itemId}`);
+    } else if (item.tag === '투표') {
+      navigate(`/bookclub/${bookclubId}/notices/${itemId}`);
+    } else if (item.tag === '공지') {
+      navigate(`/bookclub/${bookclubId}/notices/${itemId}`);
     }
   };
 
   return (
     <div
       onClick={handleCardClick}
-      className="
-        relative
-        w-[312px] h-[377px]           
-        rounded-[16px]                      
-        border-2                             
-        border-[#EAE5E2] 
-        py-[26px] px-[21.5px]                       
-        flex flex-col                       
-        overflow-hidden
-        cursor-pointer
-        select-none
-        hover:bg-gray-50
-        transition-colors"
+      className="relative w-[312px] h-[377px] rounded-[16px] border-2 border-[#EAE5E2] py-[26px] px-[21.5px] flex flex-col overflow-hidden cursor-pointer select-none hover:bg-gray-50 transition-colors"
     >
-      {/* ── 상단 헤더 ── */}
       <div className="flex justify-between items-center">
         <div className="flex items-center">
           <img src={vector} alt="icon" className="w-[24px] h-[21px]" />
-          <h3
-            className="
-              ml-[13px]
-              font-pretendard
-              font-medium
-              text-[18px]
-              leading-[135%]
-              tracking-[-0.1%]
-            "
-          >
+          <h3 className="ml-[13px] font-pretendard font-medium text-[18px] leading-[135%] tracking-[-0.1%]">
            {item.title}
          </h3>
         </div>
-        {/* 태그 */}
         <span
-          className={`
-            inline-flex
-            items-center
-            justify-center
-            w-[52px] h-[22px]
-            opacity-100
-            rounded-[15px]
-            text-[12px] text-[#FFFFFF]
-            font-pretendard
-            font-semibold
-            leading-[145%]
-            tracking-[-0.1%]
-            whitespace-nowrap
-            ${item.tag === '모임' ? 'bg-[#90D26D]' : ''}
-            ${item.tag === '투표' ? 'bg-[#FF8045]' : ''}
-            ${item.tag === '공지' ? 'bg-[#FFC648]' : ''}
-          `}
+          className={`inline-flex items-center justify-center w-[52px] h-[22px] opacity-100 rounded-[15px] text-[12px] text-[#FFFFFF] font-pretendard font-semibold leading-[145%] tracking-[-0.1%] whitespace-nowrap ${
+            item.tag === '모임' ? 'bg-[#90D26D]' : 
+            item.tag === '투표' ? 'bg-[#FF8045]' : 
+            item.tag === '공지' ? 'bg-[#FFC648]' : ''
+          }`}
         >
           {item.tag}
         </span>
       </div>
 
-      {/* ── 본문: 모임 vs 투표 vs 공지 ── */}
       <div className="mt-[9px]">
-        {item.tag === '모임' && item.meetingDate && item.book && (
-          <div className="
-            font-pretendard      
-            font-normal           
-            text-[12px]           
-            leading-[145%]        
-            tracking-[-0.1%]      
-            text-[#000000]
-            space-y-[4px]    
-             ">
-            <p>다음 모임 날짜: {item.meetingDate}</p>
-            <p>다음 모임 책: {item.book}</p>
+        {item.tag === '모임' && item.meetingInfoDTO && (
+          <div className="font-pretendard font-normal text-[12px] leading-[145%] tracking-[-0.1%] text-[#000000] space-y-[4px]">
+            <p>다음 모임 날짜: {item.meetingInfoDTO.meetingTime}</p>
+            <p>다음 모임 책: {item.meetingInfoDTO.bookInfo.title}</p>
             <div className="absolute top-[80px] right-[24px]">
              <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-2" />
             </div>
             <div className="absolute bottom-[24.5px]">
-              <div
-                className="
-                  relative
-                  w-[262px] h-[232px]
-                  bg-gray-100 rounded-lg
-                  overflow-hidden
-                  flex items-center justify-center
-                "
-              >
-                {item.imageUrl
-                  ? <img src={item.imageUrl} alt={item.title} className="w-full h-full object-cover" />
-                  : <div className="w-full h-full bg-gray-200" />
-                }
+              <div className="relative w-[262px] h-[232px] bg-gray-100 rounded-lg overflow-hidden flex items-center justify-center">
+                {item.meetingInfoDTO.bookInfo.imgUrl ? (
+                  <img src={item.meetingInfoDTO.bookInfo.imgUrl} alt={item.title} className="w-full h-full object-cover" />
+                ) : (
+                  <div className="w-full h-full bg-gray-200" />
+                )}
               </div>
             </div>
           </div>
         )}
 
-        {item.tag === '투표' && item.meetingDate && (
-          <div className="
-            font-pretendard      
-            font-normal           
-            text-[12px]           
-            leading-[145%]        
-            tracking-[-0.1%]      
-            text-[#000000]  
-            space-y-[4px]    
-           ">
-            <p>모임 날짜: {item.meetingDate}</p>
-            {item.meetingPlace && <p>모임 장소: {item.meetingPlace}</p>}
-            {item.afterPartyPlace && <p>뒤풀이 장소: {item.afterPartyPlace}</p>}
+        {item.tag === '투표' && (
+          <div className="font-pretendard font-normal text-[12px] leading-[145%] tracking-[-0.1%] text-[#000000] space-y-[4px]">
+            <p className="mt-[24px] mb-[16px] whitespace-pre-line">{item.content}</p>
             <div className="absolute top-[80px] right-[24px]">
               <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-2" />
             </div>
-            <div 
-              className="relative w-[269px] h-[207px] mt-[26px] border-[2px] border-[#EAE5E2] rounded-[16px]"
-            >
-              <div className = "mt-[14.5px] pointer-events-none" aria-hidden="true">
-                {item.voteOptions?.slice(0, 3).map((option: VoteOption) => (
-                  <label 
-                    key={option.value} 
-                    className="
-                      ml-[22.5px]
-                      flex items-center
-                      w-[224px] h-[46px]
-                      cursor-pointer
-                      border-b-2 border-[#EAE5E2]
-                      font-medium
-                      text-[14px]
-                      text-[#434343]
-                    "
+            <div className="relative w-[269px] h-[250px] mt-[26px] border-[2px] border-[#EAE5E2] rounded-[16px]">
+              <div className="mt-[14.5px] pointer-events-none" aria-hidden="true">
+                {item.items?.slice(0, 3).map((option: voteItemDto, index: number) => (
+                  <label
+                    key={`${option.item}-${index}`}
+                    className="ml-[22.5px] flex items-center w-[224px] h-[46px] cursor-pointer border-b-2 border-[#EAE5E2] font-medium text-[14px] text-[#434343]"
                   >
-                  <span
-                    aria-hidden="true"
-                    className="
-                      w-[24px] h-[24px]
-                      border-2 border-[#BBBBBB]
-                      rounded-full
-                      mr-2
-                      bg-white
-                    "
-                  />
-                  <span className="ml-[12px]">{option.label}</span>
-                </label>
-              ))}
-              <div
-                className="
-                  absolute
-                  right-[22.5px] bottom-[16px]
-                  w-[69px] h-[24px]
-                  bg-[#FF8045] 
-                  text-white 
-                  rounded-[15px]
-                  font-semibold
-                  text-[12px]               
-                  whitespace-nowrap
-                  flex items-center justify-center
-                "
-              >
-                투표하기
+                    <span
+                      aria-hidden="true"
+                      className="w-[24px] h-[24px] border-2 border-[#BBBBBB] rounded-full mr-2 bg-white"
+                    />
+                    <span className="ml-[12px]">{option.item}</span>
+                  </label>
+                ))}
+                <div className="absolute right-[22.5px] bottom-[16px] w-[69px] h-[24px] bg-[#FF8045] text-white rounded-[15px] font-semibold text-[12px] whitespace-nowrap flex items-center justify-center">
+                  투표하기
+                </div>
               </div>
             </div>
           </div>
-        </div>
         )}
 
-        <div className="mt-[9px]">
         {item.tag === '공지' && (
-          <div className="   
-            font-normal           
-            text-[12px]           
-            text-[#000000]
-            space-y-[4px]    
-             ">
-            <p className="mt-[24px] font-normal text-[12px] whitespace-pre-line">{item.announcement}</p>
+          <div className="mt-[9px]">
+            <div className="font-normal text-[12px] text-[#000000] space-y-[4px]">
+              <p className="mt-[24px] font-normal text-[12px] whitespace-pre-line">{item.content}</p>
+            </div>
           </div>
         )}
-        </div>
       </div>
     </div>
   );

--- a/src/components/BookClub/AnnouncementCard.tsx
+++ b/src/components/BookClub/AnnouncementCard.tsx
@@ -29,16 +29,11 @@ function AnnouncementCardItem({
   type RouteParams = { bookclubId?: string };
   const { bookclubId } = useParams<RouteParams>();
 
-  const handleCardClick = () => {
-    const itemId = item.id || 1;
-    if (item.tag === '모임') {
-      navigate(`/bookclub/${bookclubId}/notices/${itemId}`);
-    } else if (item.tag === '투표') {
-      navigate(`/bookclub/${bookclubId}/notices/${itemId}`);
-    } else if (item.tag === '공지') {
-      navigate(`/bookclub/${bookclubId}/notices/${itemId}`);
-    }
-  };
+	const handleCardClick = () => {
+		if (!bookclubId) return;
+		const noticeId = item.id;
+		navigate(`/bookclub/${bookclubId}/notices/${noticeId}`);
+	};
 
   return (
     <div

--- a/src/hooks/BookClub/useClubNotices.ts
+++ b/src/hooks/BookClub/useClubNotices.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { noticeListItemDto } from '../../types/clubNotice';
+import { getClubNotices } from '../../apis/clubAnnouncements/clubNoticeApi';
+
+interface UseClubNoticesProps {
+  clubId: number;
+  onlyImportant?: boolean;
+  size?: number;
+}
+
+interface UseClubNoticesReturn {
+  notices: noticeListItemDto[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  hasNext: boolean;
+  staff: boolean;
+}
+
+/**
+ * 북클럽 공지사항을 조회하는 커스텀 훅
+ */
+export const useClubNotices = ({ 
+  clubId, 
+  onlyImportant = true,
+  size = 5 
+}: UseClubNoticesProps): UseClubNoticesReturn => {
+  const queryKey = useMemo(() => ['clubNotices', clubId, onlyImportant, size], [clubId, onlyImportant, size]);
+
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey,
+    queryFn: () => getClubNotices(clubId, onlyImportant, undefined, size),
+    enabled: !!clubId && clubId > 0,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  return {
+    notices: data?.noticeList ?? [],
+    loading: isLoading,
+    error: isError ? (error as Error).message : null,
+    refetch: async () => { await refetch(); },
+    hasNext: data?.hasNext ?? false,
+    staff: data?.staff ?? false,
+  };
+};

--- a/src/hooks/BookClub/useClubNotices.ts
+++ b/src/hooks/BookClub/useClubNotices.ts
@@ -38,7 +38,20 @@ export const useClubNotices = ({
   return {
     notices: data?.noticeList ?? [],
     loading: isLoading,
-    error: isError ? (error as Error).message : null,
+    error: isError
+      ? (() => {
+          const err = error as unknown;
+          if (typeof err === 'object' && err && 'isAxiosError' in (err as any)) {
+            const axiosErr = err as any;
+            return (
+              axiosErr.response?.data?.message ??
+              axiosErr.message ??
+              '알 수 없는 오류가 발생했습니다.'
+            );
+          }
+          return (err as Error)?.message ?? '알 수 없는 오류가 발생했습니다.';
+        })()
+      : null,
     refetch: async () => { await refetch(); },
     hasNext: data?.hasNext ?? false,
     staff: data?.staff ?? false,

--- a/src/pages/BookClub/BookClubHomePage.tsx
+++ b/src/pages/BookClub/BookClubHomePage.tsx
@@ -1,70 +1,33 @@
 import { Link } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
-import AnnouncementCard, { type AnnouncementCardProps } from '../../components/BookClub/AnnouncementCard';
-import { NotificationItem, type NotificationItemProps } from '../../components/BookClub/NotificationItem';
+import AnnouncementCard from '../../components/BookClub/AnnouncementCard';
 import BookStoryCard, { type BookStoryCardProps } from '../../components/BookClub/BookStoryCard';
-import type { ClubDto } from '../../types/dto';
-import { BOOK_CATEGORIES, PARTICIPANT_TYPES } from '../../types/dto';
-import checkerImage from '../../assets/images/checker.png';
+import type { noticeListItemDto } from '../../types/clubNotice';
+import { useClubNotices } from '../../hooks/BookClub/useClubNotices';
 import userImage from '../../assets/images/userImage.png';
 import Header from '../../components/Header';
 interface Params {
-  clubId: string;
+  bookclubId: string;
   [key: string]: string | undefined;
 }
 
+// 변환 없이 API DTO 그대로 사용
+
 export default function BookClubHomePage(): React.ReactElement {
-  const { clubId } = useParams<Params>();
+  const { bookclubId } = useParams<Params>();
+  const numericClubId = Number.isFinite(Number(bookclubId)) && Number(bookclubId) > 0 ? Number(bookclubId) : 0;
+  
+  // API 훅 사용
+  const { notices, loading, error } = useClubNotices({ 
+    clubId: numericClubId,
+    onlyImportant: true,
+    size: 5 
+  });
 
-  // ── ClubDto 더미 데이터 ──
-  const dummyClubData: ClubDto = {
-    clubId: Number(clubId) || 1,
-    name: '북적북적',
-    description: '함께 읽고 토론하는 즐거운 독서 모임입니다. 매주 다양한 책을 읽고 의견을 나눕니다.',
-    profileImageUrl: checkerImage,
-    open: true,
-    category: [2, 3, 6], // 소설/시/희곡, 에세이, 인문학
-    participantTypes: [PARTICIPANT_TYPES.STUDENT, PARTICIPANT_TYPES.WORKER, PARTICIPANT_TYPES.OFFLINE],
-    region: '서울',
-    purpose: '독서 토론 및 친목 도모',
-    insta: '@bookclub_official',
-    kakao: 'bookclub_chat'
-  };
-
-  // ── 더미 데이터 (임시) ──
-  const dummyAnnouncements: AnnouncementCardProps[] = [
-    {
-      title: '북적북적',
-      tag: '모임',
-      meetingDate: '2025.06.12',
-      book: '넥서스',
-      imageUrl: checkerImage,
-    },
-    {
-      title: '5/24 모임 투표',
-      tag: '투표',
-      meetingDate: '2025.06.12 · 18시',
-      meetingPlace: '카페 모임',
-      afterPartyPlace: '맛집',
-      voteOptions: [
-        { label: '참여', value: 'yes' },
-        { label: '토론만 참여', value: 'talk' },
-        { label: '불참', value: 'no' },
-      ],
-      onVoteSubmit: (selectedValue) => {
-        console.log(`Selected vote: ${selectedValue}`);
-      },
-    },
-  ];
-
-  const dummyNotifications: NotificationItemProps[] = [
-    { message: '이현서님이 팔로우했습니다.', date: '2025.05.21 13:05 ', read: false },
-    { message: '이현서님이 팔로우했습니다.', date: '2025.05.21 13:05 ', read: false },
-    { message: '이현서님이 팔로우했습니다.', date: '2025.05.21 13:05 ', read: false },
-    { message: '이현서님이 팔로우했습니다.', date: '2025.05.21 13:05 ', read: false },
-    { message: '이현서님이 팔로우했습니다.', date: '2025.05.21 13:05 ', read: false },
-    { message: '이현서님이 팔로우했습니다.', date: '2025.05.21 13:05 ', read: false },
-  ];
+  // API 데이터에서 공지/투표만 필터링
+  const filteredNotices: noticeListItemDto[] = notices.filter((notice) =>
+    notice.tag === '공지' || notice.tag === '투표'
+  );
 
   const dummyStories: BookStoryCardProps[] = [
     {
@@ -87,10 +50,7 @@ export default function BookClubHomePage(): React.ReactElement {
 
   return (
     <div className="absolute left-[315px] right-[42px] opacity-100">
-      <Header pageTitle={`${dummyClubData.name} 홈`} userProfile={{
-          username: 'dayoun',
-          bio: '아 피곤하다.'
-        }} 
+      <Header pageTitle={`${bookclubId} 홈`} //추후 수정 필요
         customClassName="mt-[30px]"
         />
       { /* ── 메인 컨텐츠 ── */}
@@ -100,18 +60,43 @@ export default function BookClubHomePage(): React.ReactElement {
           <section className="w-full">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-[18px] font-semibold">공지사항</h2>  
-              <Link to={`/bookclub/${clubId}/notices`} className="text-[14px] text-[#969696] mr-11 hover:underline">
+              <Link to={`/bookclub/${bookclubId}/notices`} className="text-[14px] text-[#969696] mr-11 hover:underline">
                 + 더보기
               </Link>
             </div>
-            <AnnouncementCard items={dummyAnnouncements} />
+            
+            {/* 로딩 상태 */}
+            {loading && (
+              <div className="w-full h-[377px] flex items-center justify-center border-2 border-[#EAE5E2] rounded-[16px]">
+                <p className="text-[#969696]">공지사항을 불러오는 중...</p>
+              </div>
+            )}
+            
+            {/* 에러 상태 */}
+            {error && (
+              <div className="w-full h-[377px] flex items-center justify-center border-2 border-[#EAE5E2] rounded-[16px]">
+                <p className="text-red-500">{error}</p>
+              </div>
+            )}
+            
+            {/* 공지사항 데이터 */}
+            {!loading && !error && filteredNotices.length > 0 && (
+              <AnnouncementCard items={filteredNotices} />
+            )}
+            
+            {/* 공지사항이 없는 경우 */}
+            {!loading && !error && filteredNotices.length === 0 && (
+              <div className="w-full h-[377px] flex items-center justify-center border-2 border-[#EAE5E2] rounded-[16px]">
+                <p className="text-[#969696]">아직 등록된 중요 공지사항이 없습니다.</p>
+              </div>
+            )}
           </section>
 
           {/* ── 책 이야기 섹션 ── */}
           <section className="w-full h-[376px] mb-[60px]">
             <div className="flex justify-between items-center mb-[20px]">
               <h2 className="text-[18px] font-semibold">책 이야기</h2>
-              <Link to={`/bookclub/${clubId}/notifications`} className="text-[14px] text-[#8D8D8D] mr-3 hover:underline">
+              <Link to={`/bookclub/${bookclubId}/notifications`} className="text-[14px] text-[#8D8D8D] mr-3 hover:underline">
                   + 더보기
               </Link>
             </div>

--- a/src/pages/BookClub/BookClubHomePage.tsx
+++ b/src/pages/BookClub/BookClubHomePage.tsx
@@ -77,7 +77,7 @@ export default function BookClubHomePage(): React.ReactElement {
           <section className="w-full">
             <div className="flex justify-between items-center mb-4">
               <h2 className="text-[18px] font-semibold">공지사항</h2>  
-              <Link to={`/bookclub/${bookclubId}/notices`} className="text-[14px] text-[#969696] mr-11 hover:underline">
+              <Link to={`/bookclub/${numericClubId}/notices`} className="text-[14px] text-[#969696] mr-11 hover:underline">
                 + 더보기
               </Link>
             </div>

--- a/src/pages/BookClub/BookClubHomePage.tsx
+++ b/src/pages/BookClub/BookClubHomePage.tsx
@@ -1,11 +1,12 @@
 import { Link } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 import AnnouncementCard from '../../components/BookClub/AnnouncementCard';
-import BookStoryCard, { type BookStoryCardProps } from '../../components/BookClub/BookStoryCard';
+import  { type BookStoryCardProps } from '../../components/BookClub/BookStoryCard';
 import type { noticeListItemDto } from '../../types/clubNotice';
 import { useClubNotices } from '../../hooks/BookClub/useClubNotices';
 import userImage from '../../assets/images/userImage.png';
 import Header from '../../components/Header';
+import BookStoriesCard from '../../components/Main/BookStoriesCard';
 interface Params {
   bookclubId: string;
   [key: string]: string | undefined;
@@ -29,22 +30,38 @@ export default function BookClubHomePage(): React.ReactElement {
     notice.tag === '공지' || notice.tag === '투표'
   );
 
-  const dummyStories: BookStoryCardProps[] = [
+  const bookstories = [
     {
-      userName: 'hy',
-      userImage: userImage,
-      isSubscribed: false,
-      title: '나는 나이든 왕자다',
-      summary: '어린 왕자는 소행성의 주인이므로 어린 군주라는 뜻이다.어린 왕자는 B-612에서 바오밥나무 싹을 캐거나 석양을 보며 살고 있다. B-612는 크기가 너무 ...',
+      id: 1,
+      title: "북적북적",
+      story:
+        "줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.",
+      state: "구독 중",
       likes: 12,
     },
     {
-      userName: 'lee',
-      userImage: userImage,
-      isSubscribed: true,
-      title: '나는 나이든 왕자다',
-      summary: '어린 왕자는 소행성의 주인이므로 어린 군주라는 뜻이다.어린 왕자는 B-612에서 바오밥나무 싹을 캐거나 석양을 보며 살고 있다. B-612는 크기가 너무 ...',
-      likes: 8,
+      id: 2,
+      title: "인간실격",
+      story:
+        "줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.",
+      state: "구독 중",
+      likes: 193,
+    },
+    {
+      id: 3,
+      title: "홍학의 자리",
+      story:
+        "줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.",
+      state: "구독 중",
+      likes: 2003,
+    },
+    {
+      id: 4,
+      title: "홍학의 자리",
+      story:
+        "줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다. 줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.줄거리 들어갈 부분입니다.",
+      state: "구독 중",
+      likes: 2003,
     },
   ];
 
@@ -101,8 +118,10 @@ export default function BookClubHomePage(): React.ReactElement {
               </Link>
             </div>
             <div className="grid grid-cols-2 gap-[25px]">
-              {dummyStories.map((s, idx) => (
-                <BookStoryCard key={idx} {...s} />
+              {bookstories.map((story) => (
+                <div key={story.id} className="flex-shrink-0 w-[33rem]">
+                  <BookStoriesCard {...story} />
+                </div>
               ))}
             </div>
           </section>

--- a/src/types/clubNotice.ts
+++ b/src/types/clubNotice.ts
@@ -1,0 +1,133 @@
+import type { ApiResponse } from "./apiResponse";
+
+// 일반 공지사항 상세보기
+export type generalNoticeItemDto = {
+  id: number;
+  title: string;
+  content: string;
+  important: boolean;
+  tag: '공지'
+}
+
+export type generalNoticeResult = {
+  noticeItem: generalNoticeItemDto;
+  staff: boolean;
+};
+
+export type generalNoticeResponse = ApiResponse<generalNoticeResult>
+
+// 투표 공지사항 상세보기
+export type voteMembersDto = {
+  nickname: string;
+  profileImageUrl: string;
+}
+
+export type voteItemDto = {
+  item: string;
+  voteCount: number;
+  votedMembers: voteMembersDto[];
+  selected: boolean;
+}
+
+export type voteItemListDto = {
+  items: voteItemDto[];
+}
+
+export type voteNoticeItemDto = {
+  id: number;
+  title: string;
+  content: string;
+  items: voteItemListDto;
+}
+
+export type voteNoticeResult = {
+  noticeItem: voteNoticeItemDto;
+  staff: boolean;
+}
+
+export type voteNoticeResponse = ApiResponse<voteNoticeResult>
+
+// 모임 공지사항 상세보기
+export type bookInfoDto = {
+  bookId: string;
+  title: string;
+  author: string;
+  imgUrl: string;
+}
+
+export type meetingInfoDto = {
+  meetingId: number
+  title: string;
+  meetingTime: string;
+  location: string;
+  generation: number;
+  tag: string;
+  content: string;
+  bookInfo: bookInfoDto;
+}
+
+export type authorInfoDto = {
+  nickname: string;
+  profileImageUrl: string;
+}
+
+export type topicInfoDto = {
+  topicId: number;
+  content: string;
+  authorInfo: authorInfoDto;
+  teamNumbers: number[];
+}
+
+export type topicListDto = {
+  topics: topicInfoDto[];
+}
+
+export type TeamTopicDto = {
+  topicId: number
+  content: string
+  authorInfo: authorInfoDto
+  teamNumbers: number[] | null
+}
+
+export type TeamTopicListDto = {
+  topics: TeamTopicDto[]
+}
+
+export type teamDto = {
+  teamNumber: number;
+  topics: TeamTopicListDto;
+}
+
+export type teamListDto = {
+  teams: teamDto[];
+}
+
+export type meetingNoticeResult = {
+  meetingInfo: meetingInfoDto;
+  topics: topicListDto;
+  teams: teamListDto;
+}
+
+export type meetingNoticeResponse = ApiResponse<meetingNoticeResult>
+
+
+// 공지사항 목록 DTO (실제 API 응답 구조)
+export type noticeListItemDto = {
+  id: number;
+  title: string;
+  important: boolean;
+  tag: '공지' | '모임' | '투표';
+  content?: string; // 공지/모임 타입에 포함
+  items?: voteItemDto[]; // 투표 타입에만 포함
+  meetingInfoDTO?: meetingInfoDto; // 모임 타입에만 포함
+};
+
+export type noticeListResult = {
+  noticeList: noticeListItemDto[];
+  hasNext: boolean;
+  nextCursor: number | null;
+  pageSize: number;
+  staff: boolean;
+};
+
+export type clubNoticeListResponse = ApiResponse<noticeListResult>


### PR DESCRIPTION
# 제목 [feat] 독서모임(북클럽) 홈화면 - 공지사항 API 연동

## 작업내용

1. 공지사항 카드 컴포넌트 api 연동
2. 북클럽 홈화면 공지사항 부분 api 연동
# 제목 [feat] 독서모임(북클럽) 홈화면 - 공지사항 API 연동

## 작업내용

1. 공지사항 카드 컴포넌트 api 연동
2. 북클럽 홈화면 공지사항 부분 api 연동


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 북클럽 홈에서 공지/투표/모임 공지를 API로 실시간 불러와 로딩·에러·빈 상태를 표시합니다.
  - 모임 공지에 모임 시간·도서 제목·이미지(가능 시)를 노출하고, 투표 카드는 옵션 미리보기와 “투표하기” 진입 배너를 제공합니다.
  - 헤더·경로·“더보기” 링크가 북클럽 ID에 따라 동적으로 동작합니다.
- Refactor
  - 공지 데이터 표현을 통합해 표시 일관성과 데이터 흐름을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->