### PR TITLE
[Bug] Shelf, 공지생성 페이지 모달 추가 & Shelf UI 수정 & 발제,한줄평 길이 제한 + 모달

### DIFF
--- a/src/components/LongtermChatInput.tsx
+++ b/src/components/LongtermChatInput.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 
 interface ChatInputProps {
-  onSend: (text: string) => void;
+  onSend: (text: string) => boolean;
   placeholder?: string;
   buttonIconSrc?: string;
   className?: string;
@@ -44,9 +44,10 @@ const LongtermChatInput = ({
     const ta = textareaRef.current;
     if (!ta) return;
     const text = ta.value.trim();
-    onSend(text);
-    ta.value = '';
-    adjustHeight();
+    if(onSend(text)) {
+      ta.value = '';
+      adjustHeight();
+    }
   };
 
   useEffect(() => {

--- a/src/components/Shelf/ReviewSection.tsx
+++ b/src/components/Shelf/ReviewSection.tsx
@@ -24,6 +24,10 @@ function Checkdescription(description: string, Rating : number) {
       alert('한줄평을 입력해주세요.');
       return;
   }
+  else if (description.length > 100) {
+    alert('한줄평은 40자 이내로 입력해주세요.');
+    return;
+  }
   return;
 }
 

--- a/src/components/Shelf/ReviewSection.tsx
+++ b/src/components/Shelf/ReviewSection.tsx
@@ -15,32 +15,38 @@ import type {
 import LongtermChatInput from '../LongtermChatInput';
 import { getStarIcon } from './getStarIcon';
 import StarSelector from '../BookRecommend/StarSelector';
+import Modal, { type ModalButton } from '../Modal';
 
-function Checkdescription(description: string, Rating : number) {
-  if (Rating < 1) {
-      alert('별점은 1점보다 크거나 같아야 합니다.');
-      return;
-  } else if (description == '') {
-      alert('한줄평을 입력해주세요.');
-      return;
-  }
-  else if (description.length > 100) {
-    alert('한줄평은 40자 이내로 입력해주세요.');
-    return;
-  }
-  return;
-}
-
-export default function ReviewSection({ meetingId,  currentUser,  size,}: 
-  { meetingId: number;  currentUser: { nickname: string; profileImageUrl: string };  size: number;}) {
-
+export default function ReviewSection({
+  meetingId,
+  currentUser,
+  size,
+}: {
+  meetingId: number;
+  currentUser: { nickname: string; profileImageUrl: string };
+  size: number;
+}) {
   const [newRating, setNewRating] = useState<number>(0);
   const [editRating, setEditRating] = useState<number>(0);
   const [ReviewList, setReviewList] = useState<ReviewItem[]>([]);
   const [editingReviewId, setEditingReviewId] = useState<number | null>(null);
   const [editingInitialText, setEditingInitialText] = useState<string>('');
+  const [infoOpen, setInfoOpen] = useState(false);
+  const [infoTitle, setInfoTitle] = useState('');
+  const infoButtons: ModalButton[] = [
+    {
+      label: '돌아가기',
+      onClick: () => setInfoOpen(false),
+    },
+  ];
+
   const reviewReq: ReviewListRequest = { meetingId, size } as ReviewListRequest;
-  const {  data: ReviewResult,  fetchNextPage,  hasNextPage,  isFetchingNextPage,} = useReviewInfinite(reviewReq);
+  const {
+    data: ReviewResult,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useReviewInfinite(reviewReq);
 
   useEffect(() => {
     if (ReviewResult) {
@@ -66,15 +72,37 @@ export default function ReviewSection({ meetingId,  currentUser,  size,}:
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  function Checkdescription(description: string, Rating: number) {
+    if (Rating < 1) {
+      setInfoTitle('별점이 1점보다 커야 합니다.');
+      setInfoOpen(true);
+      return false;
+    } else if (description == '') {
+      setInfoTitle('한줄평을 입력해주세요.');
+      setInfoOpen(true);
+      return false;
+    } else if (description.length > 40) {
+      setInfoTitle('한줄평은 40자 이내로 입력해주세요.');
+      setInfoOpen(true);
+      return false;
+    }
+    return true;
+  }
+
   // Create
   const createReviewMut = useReviewCreate({ meetingId, size, currentUser });
-  const handleSend = (description: string) => {
-    Checkdescription(description, newRating);
+  function handleSend(description: string) {
+    if (!Checkdescription(description, newRating)) return false;
 
     const payload: ReviewCreateRequest = { description, rate: newRating };
     createReviewMut.mutate(payload, {
-      onSuccess: () => setNewRating(0),
+      onSuccess: () => {
+        setNewRating(0);
+        description = '';
+      },
     });
+    return true;
+
   };
 
   // Update
@@ -85,16 +113,20 @@ export default function ReviewSection({ meetingId,  currentUser,  size,}:
     setEditRating(review.rate);
   };
 
-  const handleUpdate = (description: string) => {
-    Checkdescription(description, editRating);
+  function handleUpdate(description: string) {
+    if (!Checkdescription(description, editRating)) return false;
 
-    const payload: ReviewUpdateRequest = { reviewId: editingReviewId!, description: description, rate: editRating };
+    const payload: ReviewUpdateRequest = {
+      reviewId: editingReviewId!,
+      description: description,
+      rate: editRating,
+    };
     updateMut.mutate(payload, {
       onSuccess: () => {
         setEditingReviewId(null);
-        setEditingInitialText('');
       },
     });
+    return true;
   };
 
   // Delete
@@ -103,10 +135,12 @@ export default function ReviewSection({ meetingId,  currentUser,  size,}:
     deleteMut.mutate(bookReviewId);
   };
 
+  
+
   return (
     <div className="mt-[64px] flex flex-col mb-[73px]">
       <span className="mb-[22px] text-[18px] font-[Pretendard] font-medium leading-[135%] text-black">
-      한줄평
+        한줄평
       </span>
 
       {/* 등록 영역 */}
@@ -135,9 +169,19 @@ export default function ReviewSection({ meetingId,  currentUser,  size,}:
       {/* 리스트 영역 */}
       <div className="flex flex-col gap-3">
         {ReviewList.map((review) => (
-          <div key={review.bookReviewId} className="flex py-2 shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]">
+          <div
+            key={review.bookReviewId}
+            className="flex py-2 shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]"
+          >
             <div className="flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]">
-              <img src={  review.authorInfo.profileImageUrl ||'/assets/ix_user-profile-filled.svg' } className="w-[48px] h-[48px] rounded-full object-cover" alt="프로필"/>
+              <img
+                src={
+                  review.authorInfo.profileImageUrl ||
+                  '/assets/ix_user-profile-filled.svg'
+                }
+                className="w-[48px] h-[48px] rounded-full object-cover"
+                alt="프로필"
+              />
               <div className="flex-1 ml-[19px] font-semibold text-[15px] text-gray-800">
                 {review.authorInfo.nickname}
               </div>
@@ -146,41 +190,74 @@ export default function ReviewSection({ meetingId,  currentUser,  size,}:
                 {/* editingReviewId가 있을 때 없을 때 2가지 경우 */}
                 {editingReviewId === review.bookReviewId ? (
                   <div className="flex justify-end items-center">
-                    <StarSelector value={editRating} onChange={setEditRating} size={10} />
-                  </div>) : (
-                    <div className="flex justify-end items-center">
-                      {[0, 1, 2, 3, 4].map((i) => (
-                        <img key={i} src={getStarIcon(review.rate, i)}  className="w-[20px] h-[20px]"  alt={`${i + 1} star`}/>))}
-                    </div>)} 
+                    <StarSelector
+                      value={editRating}
+                      onChange={setEditRating}
+                      size={10}
+                    />
+                  </div>
+                ) : (
+                  <div className="flex justify-end items-center">
+                    {[0, 1, 2, 3, 4].map((i) => (
+                      <img
+                        key={i}
+                        src={getStarIcon(review.rate, i)}
+                        className="w-[20px] h-[20px]"
+                        alt={`${i + 1} star`}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
-
             </div>
             {/* editingReviewId가 있을 때 없을 때 2가지 경우 */}
             <div className="flex-1 flex items-center font-pretendard text-sm font-medium leading-[145%] tracking-[-0.014px] break-words whitespace-pre-wrap">
-              {editingReviewId === review.bookReviewId ? ( <LongtermChatInput onSend={handleUpdate}  placeholder={'한줄평을 수정해 주세요'}   buttonIconSrc="/assets/등록.svg" initialValue={editingInitialText} className=""/>
-              ) : (review.description)}
+              {editingReviewId === review.bookReviewId ? (
+                <LongtermChatInput
+                  onSend={handleUpdate}
+                  placeholder={'한줄평을 수정해 주세요'}
+                  buttonIconSrc="/assets/등록.svg"
+                  initialValue={editingInitialText}
+                  className=""
+                />
+              ) : (
+                review.description
+              )}
             </div>
 
             {/* editingReviewId가 있을 때, 내 아이디가 아닐 때 2가지 경우*/}
-            {editingReviewId !== review.bookReviewId && review.authorInfo.nickname === currentUser.nickname && (
-              <div className="ml-auto flex gap-[9px] mr-[25px] flex-shrink-0">
-                {editingReviewId === review.bookReviewId ? (
-                  <button onClick={() => { setEditingReviewId(null); setEditingInitialText(''); }} >
-                    <img src="/assets/취소.svg" className="w-6 h-6" alt="취소"/>
-                  </button>)
-                  : (
-                  <div className="flex gap-[9px]">
-                    <button onClick={() => startEdit(review)}>
-                      <img src="/assets/글쓰기.svg" className="w-6 h-6" alt="수정"/>
+            {editingReviewId !== review.bookReviewId &&
+              review.authorInfo.nickname === currentUser.nickname && (
+                <div className="ml-auto flex gap-[9px] mr-[25px] flex-shrink-0">
+                  {editingReviewId === review.bookReviewId ? (
+                    <button
+                      onClick={() => {
+                        setEditingReviewId(null);
+                        setEditingInitialText('');
+                      }}
+                    >
+                      <img
+                        src="/assets/취소.svg"
+                        className="w-6 h-6"
+                        alt="취소"
+                      />
                     </button>
-                    <button onClick={() => handleDelete(review.bookReviewId)}>
-                      <img src="/assets/삭제.svg" className="w-6 h-6" />
-                    </button>
-                  </div>)}
-              </div>
-            )}
-
-            
+                  ) : (
+                    <div className="flex gap-[9px]">
+                      <button onClick={() => startEdit(review)}>
+                        <img
+                          src="/assets/글쓰기.svg"
+                          className="w-6 h-6"
+                          alt="수정"
+                        />
+                      </button>
+                      <button onClick={() => handleDelete(review.bookReviewId)}>
+                        <img src="/assets/삭제.svg" className="w-6 h-6" />
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
           </div>
         ))}
         {isFetchingNextPage && (
@@ -191,6 +268,12 @@ export default function ReviewSection({ meetingId,  currentUser,  size,}:
         <div ref={loadMoreRef} style={{ height: 1 }} />
         <div className="h-20" />
       </div>
+      <Modal
+        isOpen={infoOpen}
+        title={infoTitle}
+        buttons={infoButtons}
+        onBackdrop={() => setInfoOpen(false)}
+      />
     </div>
   );
 }

--- a/src/pages/BookClub/Shelf/ScoreDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ScoreDetailPage.tsx
@@ -13,9 +13,15 @@ export default function ScoreDetailPage() {
   const { bookTitle } = location.state as { bookTitle: string };
 
   useEffect(() => {
-    setMynickname('oz');
-    setUrl('/assets/ix_user-profile-filled.svg');
-  }, []);
+    const nickname = localStorage.getItem('nickname');
+    const profileImageUrl = localStorage.getItem('profileImageUrl');
+    if(!nickname || !profileImageUrl) {
+      console.log("error처리")
+      return;
+    }
+    setMynickname(nickname);
+    setUrl(profileImageUrl);
+  }, []) 
 
   return (
     <div className="flex h-screen">

--- a/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
@@ -18,8 +18,14 @@ export default function ShelfDetailPage() {
   const topics = ShelfDetail?.topicList.topics
 
   useEffect(() => {
-    setMynickname('oz')
-    setUrl('/assets/ix_user-profile-filled.svg')
+    const nickname = localStorage.getItem('nickname');
+    const profileImageUrl = localStorage.getItem('profileImageUrl');
+    if(!nickname || !profileImageUrl) {
+      console.log("error처리")
+      return;
+    }
+    setMynickname(nickname);
+    setUrl(profileImageUrl);
   }, []) 
 
   if (isLoading) return <div className = "font-[Pretendard] font-semibold text-[16px] text-[#8D8D8D]">로딩 중…</div>

--- a/src/pages/BookClub/Shelf/ShelfHomePage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfHomePage.tsx
@@ -103,7 +103,7 @@ export default function ShelfHomePage() {
            </div>
           </div>
               {/* 책장 리스트 */}
-              <div className="grid grid-cols-3 gap-x-[12px] gap-y-[24px] overflow-y-auto h-[calc(100vh-171px)] overscroll-none "  style={{ msOverflowStyle: 'none', scrollbarWidth: 'none' }}>
+              <div className="grid grid-cols-3 content-start gap-x-[12px] gap-y-[24px] overflow-y-auto h-[calc(100vh-171px)] overscroll-none "  style={{ msOverflowStyle: 'none', scrollbarWidth: 'none' }}>
                 {ShelfList.map((Shelf) => (
               <Link key={Shelf.meetingInfo.meetingId} to={`${location.pathname}/${Shelf.meetingInfo.meetingId}`} className="flex min-w-90 h-[260px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] hover:shadow-lg transition-shadow block">
                   {/* 왼쪽 */}

--- a/src/pages/BookClub/Shelf/TopicDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/TopicDetailPage.tsx
@@ -24,7 +24,7 @@ export default function ThemeDetailPage() {
   const [infoTitle, setInfoTitle] = useState('');
   const infoButtons: ModalButton[] = [
     {
-      label: '돌아가기',
+      label: '확인',
       onClick: () => setInfoOpen(false),
     },
   ];

--- a/src/pages/BookClub/Shelf/TopicDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/TopicDetailPage.tsx
@@ -7,6 +7,7 @@ import { useTopicCreate } from '../../../hooks/Shelf/useTopicCreate';
 import LongtermChatInput from '../../../components/LongtermChatInput';
 import { useTopicUpdate } from '../../../hooks/Shelf/useTopicUpdate';
 import { useTopicDelete } from '../../../hooks/Shelf/useTopicDelete';
+import Modal, { type ModalButton } from '../../../components/Modal';
 
 export default function ThemeDetailPage() {
   const navigate = useNavigate();
@@ -19,6 +20,14 @@ export default function ThemeDetailPage() {
   const [TopicList, setTopicList] = useState<TopicItem[]>([]);
   const [editingTopicId, setEditingTopicId] = useState<number | null>(null);
   const [editingInitialText, setEditingInitialText] = useState<string>('');
+  const [infoOpen, setInfoOpen] = useState(false);
+  const [infoTitle, setInfoTitle] = useState('');
+  const infoButtons: ModalButton[] = [
+    {
+      label: '돌아가기',
+      onClick: () => setInfoOpen(false),
+    },
+  ];
 
   const Req: TopicListRequest = { meetingId : Number(ShelfmeetingId), size: 5}
   const {  data: TopicResult,  fetchNextPage,  hasNextPage,  isFetchingNextPage,} = useTopicInfinite(Req);
@@ -59,18 +68,25 @@ export default function ThemeDetailPage() {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);  
 
 
+  function Checkdescription(description: string) {
+    if (description == '') {
+      setInfoTitle('발제를 입력해주세요.');
+      setInfoOpen(true);
+      return false;
+    } else if (description.length > 255) {
+      setInfoTitle('발제는 255자 이내로 입력해주세요.');
+      setInfoOpen(true);
+      return false;
+    }
+    return true;
+  }
   //create
   const createTopicMut = useTopicCreate({ meetingId: Number(ShelfmeetingId), size: 5, currentUser: { nickname: Mynickname, profileImageUrl: MyUrl } });
-  const handleSend = (description: string) => {
-    if (!description.trim()) {
-      alert('발제를 입력해주세요.');
-      return;
-    } else if (description.length > 255) {
-      alert('발제는 255자 이내로 입력해주세요.');
-      return;
-    }
+  function handleSend(description: string) {
+    if(Checkdescription(description) === false) return false;
     const payload: TopicCreateRequest = { description };
     createTopicMut.mutate(payload);
+    return true
   };
 
   //update
@@ -79,18 +95,15 @@ export default function ThemeDetailPage() {
       setEditingTopicId(topic.topicId);
       setEditingInitialText(topic.content);
     };
-  
-    const handleUpdate = (newDescription: string) => {
-      if (!newDescription.trim()) {
-        alert('발제 내용을 입력해 주세요.');
-        return;
-    }
-      
+
+    function handleUpdate(newDescription: string) {
+      if(Checkdescription(newDescription) === false) return false;
       const payload: TopicUpdateRequest = { topicId: editingTopicId!, description: newDescription };
       updateMut.mutate(payload);
 
       setEditingTopicId(null);
       setEditingInitialText('');
+      return true
     };
 
   //delete
@@ -180,6 +193,12 @@ export default function ThemeDetailPage() {
           </div>
           
       </div>
+      <Modal
+        isOpen={infoOpen}
+        title={infoTitle}
+        buttons={infoButtons}
+        onBackdrop={() => setInfoOpen(false)}
+      />
     </div>
   )
 }

--- a/src/pages/BookClub/Shelf/TopicDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/TopicDetailPage.tsx
@@ -24,9 +24,15 @@ export default function ThemeDetailPage() {
   const {  data: TopicResult,  fetchNextPage,  hasNextPage,  isFetchingNextPage,} = useTopicInfinite(Req);
 
   useEffect(() => {
-      setMynickname('oz')
-      setUrl('/assets/ix_user-profile-filled.svg')
-    }, []) 
+    const nickname = localStorage.getItem('nickname');
+    const profileImageUrl = localStorage.getItem('profileImageUrl');
+    if(!nickname || !profileImageUrl) {
+      console.log("error처리")
+      return;
+    }
+    setMynickname(nickname);
+    setUrl(profileImageUrl);
+  }, []) 
   
   useEffect(() => {
     if (TopicResult) {
@@ -58,6 +64,9 @@ export default function ThemeDetailPage() {
   const handleSend = (description: string) => {
     if (!description.trim()) {
       alert('발제를 입력해주세요.');
+      return;
+    } else if (description.length > 255) {
+      alert('발제는 255자 이내로 입력해주세요.');
       return;
     }
     const payload: TopicCreateRequest = { description };
@@ -129,7 +138,7 @@ export default function ThemeDetailPage() {
               {TopicList.map((Topic: TopicItem) => (
                 <div key={Topic.topicId} className="flex py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]">
                     <div className= "flex-shrink-0 items-center w-[222px] h-[48px] ml-[12px] flex gap-[19px] mr-[15px] " >
-                      <img src= "/assets/ix_user-profile-filled.svg" className="w-[48px] h-[48px] rounded-full object-cover" />
+                      <img src= {Topic.authorInfo.profileImageUrl || '/assets/ix_user-profile-filled.svg'} className="w-[48px] h-[48px] rounded-full object-cover" />
                       <div className="font-semibold text-[15px] text-gray-800 mb-1">{Topic.authorInfo.nickname}</div>
                     </div>
                     


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 리뷰, 공지/투표, 토픽 입력에 모달 기반 안내/검증 추가로 오류·완료 메시지 제공
  - 공지 임시저장 시 확인 모달 표시
  - 메시지 전송 실패 시 입력란을 유지하도록 입력창 동작 개선

- Refactor
  - 사용자 프로필을 localStorage에서 불러오도록 변경(서가 상세/점수 상세/토픽); 아바타 기본 이미지 폴백 강화, 편집 시 입력 컴포넌트 일관화

- Style
  - 서가 그리드 정렬을 상단 기준으로 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->