### PR TITLE
feat 마이홈페이지 API 연동

### DIFF
--- a/src/apis/My/memberApi.ts
+++ b/src/apis/My/memberApi.ts
@@ -3,6 +3,9 @@ import type {
   UpdateMyProfileRequest,
   UpdateMyProfileResult,
   MyProfile,
+  FollowResponse,
+  ClubResponse,
+  NotificationResponse,
 } from "../../types/My/member";
 
 /** 내 프로필 조회 (이미 있다면 기존 함수 사용해도 됨) */
@@ -15,4 +18,38 @@ export async function patchMyProfile(
   payload: UpdateMyProfileRequest
 ): Promise<UpdateMyProfileResult> {
   return axiosInstance.patch("/members/me", payload);
+}
+
+/* -------------------- 마이홈페이지 전용 API -------------------- */
+
+export async function getMyFollowing(cursorId: number | null): Promise<FollowResponse> {
+  return axiosInstance.get<unknown, FollowResponse>(
+    "/members/me/following",
+    { params: { cursorId } }
+  );
+}
+
+export async function getMyFollower(cursorId: number | null): Promise<FollowResponse> {
+  return axiosInstance.get<unknown, FollowResponse>(
+    "/members/me/follower",
+    { params: { cursorId } }
+  );
+}
+
+/** 내가 가입한 클럽 목록: GET /api/clubs/myPage */
+export async function getMyClubs(cursorId: number | null): Promise<ClubResponse> {
+  return axiosInstance.get<unknown, ClubResponse>(
+    "/clubs/myPage",
+    { params: { cursorId } }
+  );
+}
+
+/** 알림 전체 조회: GET /api/notifications */
+export async function getMyNotifications(
+  cursorId: number | null
+): Promise<NotificationResponse> {
+  return axiosInstance.get<unknown, NotificationResponse>(
+    "/notifications",
+    { params: { cursorId } }
+  );
 }

--- a/src/hooks/My/useMember.ts
+++ b/src/hooks/My/useMember.ts
@@ -1,8 +1,31 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { getMyProfile, patchMyProfile } from "../../apis/My/memberApi";
-import type { MyProfile, UpdateMyProfileRequest, UpdateMyProfileResult } from "../../types/My/member";
-import { QK } from "../useHeader"; 
+import {
+  getMyProfile,
+  patchMyProfile,
+  getMyFollowing,
+  getMyFollower,
+  getMyClubs,
+  getMyNotifications,
+} from "../../apis/My/memberApi";
+import type {
+  MyProfile,
+  UpdateMyProfileRequest,
+  UpdateMyProfileResult,
+  FollowResponse,
+  ClubResponse,
+  NotificationResponse,
+} from "../../types/My/member";
+import { QK } from "../useHeader";
 
+/* -------------------- 마이홈 전용 QK -------------------- */
+ const QK_MY_HOME = {
+  following: "myFollowing" as const,
+  follower: "myFollower" as const,
+  myClubs: "myClubs" as const,
+  notifications: "myNotifications" as const,
+};
+
+/* -------------------- 기존 코드 -------------------- */
 export const useMyProfileQuery = () =>
   useQuery<MyProfile, Error>({
     queryKey: QK.me,
@@ -18,3 +41,42 @@ export const useUpdateMyProfile = () => {
     },
   });
 };
+
+/* -------------------- 마이홈페이지 전용 훅 -------------------- */
+
+/** 내가 팔로잉한 사람 목록 */
+export const useMyFollowingQuery = (cursorId: number | null) =>
+  useQuery<FollowResponse, Error>({
+    queryKey: [QK_MY_HOME.following, cursorId],
+    queryFn: () => getMyFollowing(cursorId),
+    refetchOnMount: "always",
+    staleTime: 0,
+  });
+
+  /** 나를 팔로우한 사람 목록 */
+export const useMyFollowerQuery = (cursorId: number | null) =>
+  useQuery<FollowResponse, Error>({
+    queryKey: [QK_MY_HOME.follower, cursorId],
+    queryFn: () => getMyFollower(cursorId),
+    refetchOnMount: "always",
+    staleTime: 0,
+  });
+
+/** 내가 가입한 클럽 목록 */
+export const useMyClubsQuery = (cursorId: number | null) =>
+  useQuery<ClubResponse, Error>({
+    queryKey: [QK_MY_HOME.myClubs, cursorId],
+    queryFn: () => getMyClubs(cursorId),
+    refetchOnMount: "always",
+    staleTime: 0,
+  });
+
+/** 알림 전체 조회 */
+export const useMyNotificationsQuery = (cursorId: number | null) =>
+  useQuery<NotificationResponse, Error>({
+    queryKey: [QK_MY_HOME.notifications, cursorId],
+    queryFn: () => getMyNotifications(cursorId),
+    refetchOnMount: "always",
+    staleTime: 0,
+  });
+  

--- a/src/types/My/member.ts
+++ b/src/types/My/member.ts
@@ -16,3 +16,54 @@ export type UpdateMyProfileRequest = {
 
 // 응답은 갱신된 내 프로필
 export type UpdateMyProfileResult = MyProfile;
+
+/* -------------------- 마이홈페이지 전용 타입 -------------------- */
+
+export type FollowItem = {
+  nickname: string;
+  profileImageUrl: string | null;
+  following: boolean;
+};
+
+export type FollowResponse = {
+  followList: FollowItem[];
+  hasNext: boolean;
+  nextCursor: number | null;
+};
+
+export type ClubItem = {
+  clubId: number;
+  name: string;
+  description: string;
+  profileImageUrl: string | null;
+  open: boolean;
+  category: string[];
+  region: string;
+  participantTypes: string[];
+  insta: string;
+  kakao: string;
+  staff: boolean;
+};
+
+export type ClubResponse = {
+  clubList: ClubItem[];
+  hasNext: boolean;
+  nextCursor: number | null;
+};
+
+export type NotificationItem = {
+  notificationId: number;
+  notificationType: "LIKE" | "COMMENT" | "FOLLOW";
+  senderNickname: string;
+  targetName: string | null;
+  read: boolean;
+  createdAt: string; // ISO 날짜 문자열
+  redirectPath: string;
+};
+
+export type NotificationResponse = {
+  notifications: NotificationItem[];
+  hasNext: boolean;
+  nextCursor: number | null;
+  pageSize: number;
+};


### PR DESCRIPTION
마이홈페이지 API 연동

- 내 프로필 조회  API 연동
- 팔로잉 목록 조회 API 연동
- 팔로워 목록 조회 API 연동
- 알림 전체 조회 API 연동
- 모임 조회 API 연동
- 페이지 새로고침해도 로그인된 상태면 정보 안 날라가도록

<img width="1919" height="962" alt="image" src="https://github.com/user-attachments/assets/9a821852-a275-4006-99d9-f6a5497960a2" />
<img width="1919" height="975" alt="image" src="https://github.com/user-attachments/assets/b5bb61c7-ed6e-45b0-9643-1246baa887cd" />
<img width="1919" height="977" alt="image" src="https://github.com/user-attachments/assets/3c4ba5d2-f20d-451d-b977-090d63855b68" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 마이홈이 실데이터 기반으로 동작하도록 업데이트: 프로필, 내 모임, 팔로잉, 팔로워, 알림을 서버에서 불러와 표시.
  - 각 섹션은 최대 5개 항목을 노출하며, 데이터가 없을 경우 안전한 기본값과 플레이스홀더를 사용.
  - 알림은 유형(좋아요/댓글/팔로우)에 따라 문구를 구성해 가독성 향상.
  - 커서 기반 페이지네이션을 지원해 더 많은 항목을 순차적으로 로드할 수 있도록 준비.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->