### PR TITLE
[feat] 내 모임 관리하기+내 구독 페이지 API 연동

### DIFF
--- a/src/apis/My/memberApi.ts
+++ b/src/apis/My/memberApi.ts
@@ -63,3 +63,8 @@ export async function leaveClub(clubId: number): Promise<void> {
 export async function unfollowMember(memberNickname: string): Promise<void> {
   return axiosInstance.delete(`/members/${memberNickname}/following`);
 }
+
+/** 팔로워 삭제: DELETE /api/members/{memberNickname}/follower */
+export async function removeFollower(memberNickname: string): Promise<void> {
+  return axiosInstance.delete(`/members/${memberNickname}/follower`);
+}

--- a/src/apis/My/memberApi.ts
+++ b/src/apis/My/memberApi.ts
@@ -53,3 +53,8 @@ export async function getMyNotifications(
     { params: { cursorId } }
   );
 }
+
+/** 내가 가입한 모임 탈퇴: DELETE /api/clubs/{clubId}/leave */
+export async function leaveClub(clubId: number): Promise<void> {
+  return axiosInstance.delete(`/clubs/${clubId}/leave`);
+}

--- a/src/apis/My/memberApi.ts
+++ b/src/apis/My/memberApi.ts
@@ -58,3 +58,8 @@ export async function getMyNotifications(
 export async function leaveClub(clubId: number): Promise<void> {
   return axiosInstance.delete(`/clubs/${clubId}/leave`);
 }
+
+/** 팔로잉 취소: DELETE /api/members/{memberNickname}/following */
+export async function unfollowMember(memberNickname: string): Promise<void> {
+  return axiosInstance.delete(`/members/${memberNickname}/following`);
+}

--- a/src/hooks/My/useMember.ts
+++ b/src/hooks/My/useMember.ts
@@ -7,7 +7,8 @@ import {
   getMyClubs,
   getMyNotifications,
   leaveClub,
-  unfollowMember
+  unfollowMember,
+  removeFollower
 } from "../../apis/My/memberApi";
 import type {
   MyProfile,
@@ -101,6 +102,18 @@ export const useUnfollowMember = () => {
     onSuccess: () => {
       // 팔로잉 목록 새로고침
       qc.invalidateQueries({ queryKey: [QK_MY_HOME.following] });
+    },
+  });
+};
+
+/** 팔로워 삭제 훅 */
+export const useRemoveFollower = () => {
+  const qc = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (nickname) => removeFollower(nickname),
+    onSuccess: () => {
+      // 팔로워 목록 새로고침
+      qc.invalidateQueries({ queryKey: [QK_MY_HOME.follower] });
     },
   });
 };

--- a/src/hooks/My/useMember.ts
+++ b/src/hooks/My/useMember.ts
@@ -6,6 +6,7 @@ import {
   getMyFollower,
   getMyClubs,
   getMyNotifications,
+  leaveClub
 } from "../../apis/My/memberApi";
 import type {
   MyProfile,
@@ -68,7 +69,7 @@ export const useMyClubsQuery = (cursorId: number | null) =>
     queryKey: [QK_MY_HOME.myClubs, cursorId],
     queryFn: () => getMyClubs(cursorId),
     refetchOnMount: "always",
-    staleTime: 0,
+    staleTime: 1000 * 60,
   });
 
 /** 알림 전체 조회 */
@@ -79,4 +80,15 @@ export const useMyNotificationsQuery = (cursorId: number | null) =>
     refetchOnMount: "always",
     staleTime: 0,
   });
+
+/** 내가 가입한 클럽 탈퇴 */
+export const useLeaveClub = () => {
+  const qc = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: (clubId) => leaveClub(clubId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [QK_MY_HOME.myClubs] });
+    },
+  });
+};
   

--- a/src/hooks/My/useMember.ts
+++ b/src/hooks/My/useMember.ts
@@ -6,7 +6,8 @@ import {
   getMyFollower,
   getMyClubs,
   getMyNotifications,
-  leaveClub
+  leaveClub,
+  unfollowMember
 } from "../../apis/My/memberApi";
 import type {
   MyProfile,
@@ -88,6 +89,18 @@ export const useLeaveClub = () => {
     mutationFn: (clubId) => leaveClub(clubId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: [QK_MY_HOME.myClubs] });
+    },
+  });
+};
+
+/** 팔로잉 취소 훅 */
+export const useUnfollowMember = () => {
+  const qc = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (nickname) => unfollowMember(nickname),
+    onSuccess: () => {
+      // 팔로잉 목록 새로고침
+      qc.invalidateQueries({ queryKey: [QK_MY_HOME.following] });
     },
   });
 };

--- a/src/pages/Main/Info/My/MyGroupPage.tsx
+++ b/src/pages/Main/Info/My/MyGroupPage.tsx
@@ -1,81 +1,72 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState } from "react";
 import MyPageHeader from "../../../../components/MyPageHeader";
 import { useNavigate } from "react-router-dom";
 import AlertModal from "../../../../components/AlertModal";
-
-type Group = {
-  id: number;
-  name: string;
-  description: string;
-  profileImage?: string;
-};
+import { useMyClubsQuery, useLeaveClub } from "../../../../hooks/My/useMember"; 
+import type { ClubItem } from "../../../../types/My/member";
 
 const MyGroupPage = () => {
-  const [groups, setGroups] = useState<Group[]>([]);
-  const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(true);
-  const [isFetching, setIsFetching] = useState(false);
-  const [showModal, setShowModal] = useState(false);
+  const [showConfirmModal, setShowConfirmModal] = useState(false); 
+  const [showResultModal, setShowResultModal] = useState(false);  
+  const [showErrorModal, setShowErrorModal] = useState(false); // 에러 모달
+  const [errorMessage, setErrorMessage] = useState("");         // 에러 메시지
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
+  const [errorImages, setErrorImages] = useState<Record<number, boolean>>({});
+  const [isLeaving, setIsLeaving] = useState(false); 
   const navigate = useNavigate();
 
-  const observerRef = useRef<IntersectionObserver | null>(null);
+  // 첫 페이지 호출
+  const { data, isFetching, isError, refetch } = useMyClubsQuery(null);
 
-  const fetchGroups = async () => {
-    if (isFetching || !hasMore) return;
-    setIsFetching(true);
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    const newGroups: Group[] = Array.from({ length: 3 }, (_, idx) => ({
-      id: (page - 1) * 3 + idx + 1,
-      name: ["모임 명", "짱구야 책읽자", "독서를 하자"][idx % 3],
-      description: [
-        "지치지 말아요~",
-        "세상에서 제일 귀여운 짱구와 책을 읽어보아요",
-        "독서를 합시다.",
-      ][idx % 3],
-      profileImage: "",
-    }));
-
-    setGroups((prev) => [...prev, ...newGroups]);
-    setPage((prev) => prev + 1);
-
-    if (page >= 2) setHasMore(false); // 무한스크롤 페이지 조정
-    setIsFetching(false);
-  };
-
-  useEffect(() => {
-    fetchGroups();
-  }, []);
-
-  const lastElementRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (isFetching) return;
-      if (observerRef.current) observerRef.current.disconnect();
-
-      observerRef.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && hasMore) {
-          fetchGroups();
-        }
-      });
-
-      if (node) observerRef.current.observe(node);
-    },
-    [isFetching, hasMore]
-  );
+  // 탈퇴 훅
+  const leaveClubMutation = useLeaveClub();
 
   const handleGroupClick = (id: number) => {
-    navigate(`/group/${id}`);
+    navigate(`/shelf/${id}`);
   };
 
+  // 탈퇴 실행
   const confirmLeaveGroup = () => {
-    if (selectedGroupId !== null) {
-      setGroups((prev) => prev.filter((group) => group.id !== selectedGroupId));
-      setSelectedGroupId(null);
-    }
-    setShowModal(false);
+    if (!selectedGroupId || isLeaving) return; // 이미 요청 중이면 중단
+    setIsLeaving(true);
+
+    leaveClubMutation.mutate(selectedGroupId, {
+      onSuccess: () => {
+        setIsLeaving(false);
+        setSelectedGroupId(null);
+        setShowConfirmModal(false);
+        setShowResultModal(true); // 성공 모달
+        refetch();
+      },
+      onError: (error: any) => {
+        setIsLeaving(false);
+        setSelectedGroupId(null);
+        setShowConfirmModal(false);
+
+        const code = error?.response?.data?.code;
+        const message = error?.response?.data?.message;
+
+        if (code === "CLUB_4019") {
+          setErrorMessage(message || "운영진은 클럽을 탈퇴할 수 없습니다.");
+        } else {
+          setErrorMessage(message || "탈퇴에 실패했습니다.");
+        }
+        setShowErrorModal(true);
+      },
+    });
   };
+
+  // 이미지 경로 처리 함수
+  const getImageUrl = (url: string | null) => {
+    if (!url) return null;
+    return url.startsWith("http")
+      ? url
+      : `${import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, "")}/${url.replace(/^\//, "")}`;
+  };
+
+  if (isError) {
+    return <div className="p-6 text-red-500">모임 목록을 불러오는데 실패했습니다.</div>;
+  }
 
   return (
     <div className="flex w-full h-screen bg-[#FAFAFA] overflow-hidden">
@@ -84,74 +75,113 @@ const MyGroupPage = () => {
       <div className="flex-1 flex flex-col pt-[96px] overflow-hidden">
         <main className="flex-1 overflow-y-auto">
           <div className="px-4 md:px-10 py-8 space-y-4 flex flex-col items-center">
-            {groups.map((group, idx) => (
-              <div
-                key={group.id}
-                ref={idx === groups.length - 1 ? lastElementRef : null}
-                className="w-full flex flex-col md:flex-row justify-between bg-white border border-[#EAE5E2] rounded-[16px] px-4 md:px-6 py-4 shadow-sm cursor-pointer hover:bg-[#FAFAFA]"
-                onClick={() => handleGroupClick(group.id)}
-              >
-                {/* 왼쪽: 프로필 사진 + 텍스트 */}
-                <div className="flex gap-4 md:gap-6">
-                  <div className="bg-gray-200 rounded-[16px] overflow-hidden w-[80px] h-[80px] md:w-[119px] md:h-[119px] flex-shrink-0" />
+            {data?.clubList?.map((group: ClubItem) => {
+              const imgUrl = getImageUrl(group.profileImageUrl);
+              const isErrorImage = errorImages[group.clubId] || !imgUrl;
 
-                  <div className="flex flex-col justify-between">
-                    <div>
-                      <div className="flex gap-2 mb-2 md:mb-3">
-                        <span className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2">
-                          7기
-                        </span>
-                        <span className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2">
-                          사회
-                        </span>
+              return (
+                <div
+                  key={group.clubId}
+                  className="w-full flex flex-col md:flex-row justify-between bg-white border border-[#EAE5E2] rounded-[16px] px-4 md:px-6 py-4 shadow-sm cursor-pointer hover:bg-[#FAFAFA]"
+                  onClick={() => handleGroupClick(group.clubId)}
+                >
+                  {/* 왼쪽: 프로필 사진 + 텍스트 */}
+                  <div className="flex gap-4 md:gap-6">
+                    <div className="bg-gray-200 rounded-[16px] overflow-hidden w-[80px] h-[100px] md:w-[119px] md:h-[119px] flex-shrink-0 flex items-center justify-center">
+                      {!isErrorImage ? (
+                        <img
+                          src={imgUrl!}
+                          alt={group.name}
+                          className="w-full h-full object-cover"
+                          onError={() =>
+                            setErrorImages((prev) => ({ ...prev, [group.clubId]: true }))
+                          }
+                        />
+                      ) : (
+                        <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm">
+                          No Image
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex flex-col justify-between">
+                      <div>
+                        <div className="flex gap-2 mb-2 md:mb-3">
+                          <span className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2">
+                            7기
+                          </span>
+                          {group.category.map((cat, idx) => (
+                            <span
+                              key={idx}
+                              className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2"
+                            >
+                              {cat}
+                            </span>
+                          ))}
+                        </div>
+                        <p className="text-[#2C2C2C] text-[16px] md:text-[18px] font-semibold break-keep">
+                          {group.name}
+                        </p>
+                        <p className="text-[#5C5C5C] text-[13px] md:text-[14px] break-words">
+                          {group.description}
+                        </p>
                       </div>
-                      <p className="text-[#2C2C2C] text-[16px] md:text-[18px] font-semibold break-keep">
-                        {group.name}
-                      </p>
-                      <p className="text-[#5C5C5C] text-[13px] md:text-[14px] break-words">
-                        {group.description}
-                      </p>
                     </div>
                   </div>
-                </div>
 
-                {/* 오른쪽: 탈퇴 버튼 */}
-                <div className="flex justify-end md:items-end mt-4 md:mt-0">
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setSelectedGroupId(group.id);
-                      setShowModal(true);
-                    }}
-                    className="text-[#5C5C5C] border border-[#EAE5E2] rounded-full hover:bg-[#90D26D] hover:text-white w-[90px] md:w-[105px] h-[32px] md:h-[35px] text-sm mt-auto"
-                  >
-                    탈퇴하기
-                  </button>
+                  {/* 오른쪽: 탈퇴 버튼 */}
+                  <div className="flex justify-end md:items-end mt-4 md:mt-0">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSelectedGroupId(group.clubId);
+                        setShowConfirmModal(true);
+                      }}
+                      disabled={isLeaving} // 요청 중이면 버튼 비활성화
+                      className={`text-[#5C5C5C] border border-[#EAE5E2] rounded-full w-[90px] md:w-[105px] h-[32px] md:h-[35px] text-sm mt-auto 
+                        ${isLeaving ? "opacity-50 cursor-not-allowed" : "hover:bg-[#90D26D] hover:text-white"}`}
+                    >
+                      탈퇴하기
+                    </button>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
 
             {isFetching && (
               <p className="text-center text-gray-400">불러오는 중...</p>
-            )}
-
-            {!hasMore && !isFetching && (
-              <p className="text-center text-gray-400 mt-6">
-                더 이상 모임이 없습니다.
-              </p>
             )}
           </div>
         </main>
       </div>
 
-      {showModal && (
+      {/* 확인 모달 */}
+      {showConfirmModal && (
         <AlertModal
           message="정말 탈퇴 하시겠습니까?"
           onConfirm={confirmLeaveGroup}
           onClose={() => {
-            setShowModal(false);
+            setShowConfirmModal(false);
             setSelectedGroupId(null);
           }}
+        />
+      )}
+
+      {/* 결과 모달 */}
+      {showResultModal && (
+        <AlertModal
+          message="탈퇴되었습니다."
+          onConfirm={() => setShowResultModal(false)}
+          onClose={() => setShowResultModal(false)} 
+        />
+      )}
+
+      {/* 에러 모달 */}
+      {showErrorModal && (
+        <AlertModal
+          message={errorMessage}
+          onConfirm={() => setShowErrorModal(false)}
+          onClose={() => setShowErrorModal(false)}
         />
       )}
     </div>

--- a/src/pages/Main/Info/My/MySubscriptionPage.tsx
+++ b/src/pages/Main/Info/My/MySubscriptionPage.tsx
@@ -1,184 +1,128 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useState } from "react";
 import MyPageHeader from "../../../../components/MyPageHeader";
 import { useNavigate } from "react-router-dom";
-
-type User = {
-  id: number;
-  nickname: string;
-  isFollowing: boolean;
-};
+import {
+  useMyFollowingQuery,
+  useUnfollowMember, 
+} from "../../../../hooks/My/useMember";
 
 const MySubscriptionPage = () => {
   const navigate = useNavigate();
-  const [followers, setFollowers] = useState<User[]>([]);
-  const [following, setFollowing] = useState<User[]>([]);
-  const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(true);
-  const [isFetching, setIsFetching] = useState(false);
   const [activeTab, setActiveTab] = useState<"followers" | "following">("followers");
 
-  const observerRef = useRef<IntersectionObserver | null>(null);
+  // 구독 목록 조회 
+  const { data, isFetching, isError } = useMyFollowingQuery(null);
 
-  const fetchData = async (pageNum: number) => {
-    setIsFetching(true);
-    await new Promise((res) => setTimeout(res, 500));
+  // 언팔로우 훅 사용
+  const unfollowMutation = useUnfollowMember();
 
-    const newFollowers: User[] = Array.from({ length: 3 }, (_, idx) => {
-      const id = 1000 + (pageNum - 1) * 3 + idx;
-      return {
-        id,
-        nickname: `닉네임 ${id}`,
-        isFollowing: true,
-      };
-    });
-
-    const newFollowing: User[] = Array.from({ length: 3 }, (_, idx) => {
-      const id = 2000 + (pageNum - 1) * 3 + idx;
-      return {
-        id,
-        nickname: `닉네임 ${id}`,
-        isFollowing: true,
-      };
-    });
-
-    setFollowers((prev) => [...prev, ...newFollowers]);
-    setFollowing((prev) => [...prev, ...newFollowing]);
-
-    if (pageNum >= 3) setHasMore(false);
-    setIsFetching(false);
+  const handleProfileClick = (nickname: string) => {
+    navigate(`/info/others/${nickname}`);
   };
 
-  useEffect(() => {
-    fetchData(1);
-  }, []);
-
-  const lastElementRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (isFetching) return;
-      if (observerRef.current) observerRef.current.disconnect();
-
-      observerRef.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && hasMore) {
-          setPage((prev) => prev + 1);
-        }
-      });
-
-      if (node) observerRef.current.observe(node);
-    },
-    [isFetching, hasMore]
-  );
-
-  useEffect(() => {
-    if (page > 1) fetchData(page);
-  }, [page]);
-
-  const toggleFollow = (
-    list: User[],
-    setList: React.Dispatch<React.SetStateAction<User[]>>,
-    id: number
-  ) => {
-    const updated = list.map((user) =>
-      user.id === id ? { ...user, isFollowing: !user.isFollowing } : user
-    );
-    setList(updated);
+  const handleUnfollow = (nickname: string) => {
+    unfollowMutation.mutate(nickname);
   };
 
-  const handleProfileClick = (id: number) => {
-    navigate(`/info/others/${id}`);
-  };
+  const renderFollowingList = () => {
+    if (isError) {
+      return <p className="text-center text-red-500">구독 목록을 불러오는데 실패했습니다.</p>;
+    }
 
-  const renderList = (
-    list: User[],
-    setList: React.Dispatch<React.SetStateAction<User[]>>
-  ) => (
-    <section className="bg-white border border-[#EAE5E2] rounded-[16px] flex flex-col">
-      <div
-        className="flex-1 max-h-[500px] overflow-y-auto divide-y divide-[#EAE5E2] hide-scrollbar"
-      >
-        <style>
-          {`
-            .hide-scrollbar::-webkit-scrollbar {
-              display: none;
-            }
-            .hide-scrollbar {
-              -ms-overflow-style: none;
-              scrollbar-width: none;
-            }
-          `}
-        </style>
+    if (!data) return null;
 
-        {list.map((user, idx) => (
-          <div
-            key={user.id}
-            ref={idx === list.length - 1 ? lastElementRef : null}
-            className="flex justify-between items-center px-8 py-5 cursor-pointer hover:bg-[#FAFAFA]"
-            onClick={() => handleProfileClick(user.id)}
-          >
-            <div className="flex items-center gap-3">
-              <div className="bg-gray-300 rounded-full w-9 h-9" />
-              <p className="text-[#2C2C2C] text-[18px] font-medium">{user.nickname}</p>
-            </div>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleFollow(list, setList, user.id);
-              }}
-              className={`px-3 py-1 rounded-full text-[13px] font-medium text-white ${
-                user.isFollowing ? "bg-[#90D26D] hover:bg-[#7bb95b]" : "bg-[#8D8D8D] hover:bg-[#aaa]"
-              }`}
+    return (
+      <section className="bg-white border border-[#EAE5E2] rounded-[16px] flex flex-col">
+        <div className="flex-1 overflow-y-auto divide-y divide-[#EAE5E2] hide-scrollbar">
+          <style>
+            {`
+              .hide-scrollbar::-webkit-scrollbar { display: none; }
+              .hide-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+            `}
+          </style>
+
+          {data.followList.map((user) => (
+            <div
+              key={user.nickname}
+              className="flex justify-between items-center px-8 py-5 cursor-pointer hover:bg-[#FAFAFA]"
+              onClick={() => handleProfileClick(user.nickname)}
             >
-              {user.isFollowing ? "삭제" : "구독"}
+              <div className="flex items-center gap-3">
+                {user.profileImageUrl ? (
+                  <img
+                    src={user.profileImageUrl}
+                    alt={`${user.nickname} 프로필`}
+                    className="rounded-full w-9 h-9 object-cover"
+                  />
+                ) : (
+                  <div className="bg-gray-300 rounded-full w-9 h-9" />
+                )}
+                <p className="text-[#2C2C2C] text-[18px] font-medium">{user.nickname}</p>
+              </div>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (user.following) {
+                    handleUnfollow(user.nickname); // ✅ 구독 해제 실행
+                  }
+                }}
+                className={`px-3 py-1 rounded-full text-[13px] font-medium text-white ${
+                  user.following
+                    ? "bg-[#90D26D] hover:bg-[#7bb95b]"
+                    : "bg-[#8D8D8D] hover:bg-[#aaa]"
+                }`}
+              >
+                {user.following ? "삭제" : "구독"}
+              </button>
+            </div>
+          ))}
+
+          {isFetching && <p className="text-center text-gray-400 py-4">불러오는 중...</p>}
+          {!data.hasNext && !isFetching && (
+            <p className="text-center text-gray-400 py-4">더 이상 사용자 없음</p>
+          )}
+        </div>
+      </section>
+    );
+  };
+
+  return (
+    <div className="flex w-full h-screen bg-[#FAFAFA] overflow-hidden">
+      <MyPageHeader title="내 구독" />
+      <div className="flex-1 flex flex-col pt-[88px] overflow-hidden">
+        <main className="flex-1 overflow-y-auto">
+          {/* 탭 */}
+          <div className="flex px-10 pt-8 gap-8">
+            <button
+              className={`text-[16px] font-semibold pb-1 border-b-2 ${
+                activeTab === "followers"
+                  ? "text-[#2C2C2C] border-[#90D26D]"
+                  : "text-gray-400 border-transparent"
+              }`}
+              onClick={() => setActiveTab("followers")}
+            >
+              구독자
+            </button>
+            <button
+              className={`text-[16px] font-semibold pb-1 border-b-2 ${
+                activeTab === "following"
+                  ? "text-[#2C2C2C] border-[#90D26D]"
+                  : "text-gray-400 border-transparent"
+              }`}
+              onClick={() => setActiveTab("following")}
+            >
+              구독 중
             </button>
           </div>
-        ))}
-        {isFetching && <p className="text-center text-gray-400 py-4">불러오는 중...</p>}
-        {!hasMore && !isFetching && <p className="text-center text-gray-400 py-4">더 이상 사용자 없음</p>}
+
+          {/* 리스트 */}
+          <div className="px-10 pt-6 pb-12">
+            {activeTab === "following" && renderFollowingList()}
+          </div>
+        </main>
       </div>
-    </section>
-  );
-
-   return (
-   <div className="flex w-full h-screen bg-[#FAFAFA] overflow-hidden">
-     {/* 헤더는 고정 */}
-     <MyPageHeader title="내 구독" />
-
-     {/* 헤더 높이 제외한 나머지를 따로 감싸서 스크롤 */}
-     <div className="flex-1 flex flex-col pt-[88px] overflow-hidden">
-       <main className="flex-1 overflow-y-auto">
-         {/* 탭 */}
-         <div className="flex px-10 pt-8 gap-8">
-           <button
-             className={`text-[16px] font-semibold pb-1 border-b-2 ${
-               activeTab === "followers"
-                 ? "text-[#2C2C2C] border-[#90D26D]"
-                 : "text-gray-400 border-transparent"
-             }`}
-             onClick={() => setActiveTab("followers")}
-           >
-             구독자
-           </button>
-           <button
-             className={`text-[16px] font-semibold pb-1 border-b-2 ${
-               activeTab === "following"
-                 ? "text-[#2C2C2C] border-[#90D26D]"
-                 : "text-gray-400 border-transparent"
-             }`}
-             onClick={() => setActiveTab("following")}
-           >
-            구독 중
-           </button>
-         </div>
-
-         {/* 리스트 */}
-         <div className="px-10 pt-6 pb-12">
-           {activeTab === "followers"
-             ? renderList(followers, setFollowers)
-             : renderList(following, setFollowing)}
-         </div>
-       </main>
     </div>
-  </div>
-);
+  );
 };
 
 export default MySubscriptionPage;


### PR DESCRIPTION
내 모임 관리하기+내 구독 페이지 API 연동

-  내가 가입한 클럽목록 전체조회 API 연동
-  내가 가입한 클럽 탈퇴 API 연동
-  운영진일 경우 탈퇴 안되고 모달 띄우기
-  해당 상세 클럽 라우트 수정
-  내 구독 페이지 회원 언팔로잉 API 연동
-  내 구독 페이지 팔로잉 목록 조회 API 연동
-  내 구독 페이지 팔로워 목록 조회 API 연동
-  내 구독 페이지 회원 팔로워 중 특정 회원 삭제 API 연동 

<img width="1917" height="972" alt="image" src="https://github.com/user-attachments/assets/185cceb9-444d-4897-a0ce-a92e82391936" />
<img width="1919" height="972" alt="image" src="https://github.com/user-attachments/assets/edc7fe92-5991-4753-9c98-b137478462a4" />
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/1926b1e7-12a7-4612-b0ac-d2bfd506b4ee" />
<img width="1918" height="968" alt="image" src="https://github.com/user-attachments/assets/0233cfd4-982b-4531-a5e4-b3b7cc6afb3a" />
<img width="1919" height="974" alt="image" src="https://github.com/user-attachments/assets/94c18608-c4e0-4065-bf9d-ee1a6f51defd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 모임 탈퇴 기능 추가: 확인/성공/오류 모달 흐름 제공, 진행 중 버튼 비활성화.
  - 구독 관리 강화: 구독 해제, 구독자 제거 액션 추가.
- UI/UX Improvements
  - 내 모임 목록 UI 개선: 이미지 로딩 오류 대응 및 플레이스홀더, 카테고리/설명 표시, 클릭 시 모임 서가로 이동.
  - 구독/구독자 탭형 목록으로 재구성: 프로필 이미지·닉네임 표시, 아이템 클릭 시 프로필로 이동, 로딩/오류/더 없음 상태 명확화.
- Performance
  - 데이터 캐싱 및 서버 주도 목록으로 전환해 응답성과 안정성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->