### PR TITLE
[fix] 헤더 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,92 +1,124 @@
 import { useState, useEffect, useRef } from "react";
 import { FaBell } from "react-icons/fa";
-import { useNavigate } from "react-router-dom";
-import { FaCircleCheck } from "react-icons/fa6";
-
-type Notification = {
-  message: string;
-  time: string;
-};
-
-type UserProfile = {
-  username: string;
-  bio: string;
-};
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getMyProfile, getNotificationPreview } from "../apis/headerApi";
 
 interface HeaderProps {
   pageTitle: string;
-  userProfile?: UserProfile;
-  notifications?: Notification[];
-  customClassName?: string; // 커스텀으로 각자 페이지에서 조정 가능
-  isAdmin?: boolean; // 운영자 여부 prop 추가
+  customClassName?: string;
+  isAdmin?: boolean;
+  showManageButton?: boolean;
+  manageLabel?: string;
+  manageTo?: string;
+  onClickManage?: () => void;
+  manageButtonClassName?: string; // 버튼 위치·크기·스타일 커스텀
 }
 
-// 기본 더미 데이터
-const defaultUserProfile: UserProfile = {
-  username: "hy_0716",
-  bio: "책을 아는가? 나는 모른다",
+const TYPE_TEXT: Record<string, string> = {
+  LIKE: "좋아요를 눌렀습니다.",
+  COMMENT: "댓글을 남겼습니다.",
+  FOLLOW: "팔로우했습니다.",
 };
 
-const defaultNotifications: Notification[] = [
-  { message: "새 댓글이 달렸습니다.", time: "2025-07-11 13:00" },
-  { message: "이현서님이 팔로우했습니다.", time: "2025-07-11 12:45" },
-  { message: "새 모임이 등록되었습니다.", time: "2025-07-10 18:30" },
-  { message: "공지사항이 업데이트되었습니다.", time: "2025-07-09 09:15" },
-  { message: "투표가 시작되었습니다.", time: "2025-07-08 14:20" },
-];
+const Header = ({
+  pageTitle,
+  customClassName,
+  isAdmin = false,
+  showManageButton = false,
+  manageLabel = "모임 관리하기",
+  manageTo: propManageTo,
+  onClickManage,
+  manageButtonClassName = "text-sm md:text-base text-[#8D8D8D] hover:text-[#2C2C2C] underline underline-offset-2 decoration-[#C4E8B2]",
+}: HeaderProps) => {
+  const navigate = useNavigate();
+  const { bookclubId } = useParams();
 
-const Header = (props: HeaderProps) => {
-  const {
-    pageTitle,
-    userProfile = defaultUserProfile,
-    notifications = defaultNotifications,
-    customClassName,
-    isAdmin = false, // 운영자인 경우 true로 쓰면 됨
-  } = props;
+  // bookclubId가 있으면 북클럽 홈 경로로, 아니면 기본값
+  const manageTo =
+    propManageTo ?? (bookclubId ? `/bookclub/${bookclubId}/home` : "/club/manage");
+
+  // 프로필
+  const { data: me, isPending: profilePending } = useQuery({
+    queryKey: ["header", "me"],
+    queryFn: getMyProfile,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    retry: 0,
+  });
+
+  // 알림 프리뷰
+  const { data: preview, isPending: notiPending } = useQuery({
+    queryKey: ["header", "preview", 5],
+    queryFn: () => getNotificationPreview(5),
+    staleTime: 30 * 1000,
+    refetchInterval: 60 * 1000,
+    retry: 0,
+  });
+
+  const notificationsToShow =
+    (preview?.notifications ?? []).slice(0, 5).map((n) => ({
+      message: `${n.senderNickname}님이 ${
+        TYPE_TEXT[n.notificationType] ?? n.notificationType
+      }`,
+      time: new Date(n.createdAt).toLocaleString(),
+      redirectPath: n.redirectPath,
+    }));
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
-  const navigate = useNavigate();
-
-  const toggleModal = () => setIsModalOpen((prev) => !prev);
-
-  const handleClickOutside = (e: MouseEvent) => {
-    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-      setIsModalOpen(false);
-    }
-  };
 
   useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        setIsModalOpen(false);
+      }
+    };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const goToMyPage = () => {
-    navigate("/mypage");
+  const unreadCount = notificationsToShow.length;
+
+  const goManage = () => {
+    if (onClickManage) onClickManage();
+    else navigate(manageTo);
   };
 
   return (
     <header
       className={`${
-        customClassName
-          ? customClassName
-          : "fixed left-[264px] right-0 top-3 h-[56px] lg:px-13 px-4 md:px-8 " // 기본값
-      } bg-white flex justify-between items-center z-50 `}
+        customClassName ??
+        "fixed left-[264px] right-0 top-3 h-[56px] lg:px-13 px-4 md:px-8 "
+      } bg-white flex justify-between items-center z-50`}
     >
-      {/* 페이지 타이틀 */}
-      <h1 className="font-bold text-lg md:text-xl lg:text-2xl text-[#2C2C2C]">
-        {pageTitle}
-      </h1>
+      {/* 타이틀 + (운영진 전용) 관리 버튼 */}
+      <div className="flex items-center gap-3">
+        <h1 className="font-bold text-lg md:text-xl lg:text-2xl text-[#2C2C2C]">
+          {pageTitle}
+        </h1>
 
-      {/* 알림 + 프로필 */}
+        {isAdmin && showManageButton && (
+          <button type="button" onClick={goManage} className={manageButtonClassName}>
+            {manageLabel}
+          </button>
+        )}
+      </div>
+
       <div className="flex items-center gap-3 md:gap-4 relative">
-        {/* 종 아이콘 */}
+        {/* 종 아이콘 + 배지 */}
         <button
-          onClick={toggleModal}
+          onClick={() => setIsModalOpen((p) => !p)}
           aria-label="Notifications"
-          className="w-8 h-8 flex justify-center items-center shrink-0"
+          className="relative w-8 h-8 flex justify-center items-center shrink-0"
+          disabled={notiPending}
         >
           <FaBell size={32} color="#90D26D" />
+          {!notiPending && unreadCount > 0 && (
+            <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-[4px] rounded-full text-[11px] bg-[#90D26D] text-white flex items-center justify-center">
+              {unreadCount}
+            </span>
+          )}
         </button>
 
         {/* 알림 모달 */}
@@ -95,44 +127,55 @@ const Header = (props: HeaderProps) => {
             ref={modalRef}
             className="absolute right-0 top-[60px] w-[300px] bg-white border-2 border-[#C4E8B2] rounded-[16px] shadow-lg p-[20px] z-50"
           >
-            <ul className="space-y-2">
-              {notifications.slice(0, 5).map((notif, index) => (
-                <li
-                  key={index}
-                  className="flex justify-between items-center px-[10px] py-[8px] hover:bg-[#F1F8EF] rounded-[12px]"
-                >
-                  <div className="flex flex-col">
-                    <span className="text-[#2C2C2C] text-[14px] font-medium leading-[145%]">
-                      {notif.message}
-                    </span>
-                    <span className="text-[#8D8D8D] text-[12px] font-normal leading-[145%]">
-                      {notif.time}
-                    </span>
-                  </div>
-                  <div className="w-[15px] h-[15px] bg-[#90D26D] rounded-full flex-shrink-0" />
-                </li>
-              ))}
-            </ul>
+            {notiPending ? (
+              <div className="text-sm text-[#8D8D8D]">알림 불러오는 중...</div>
+            ) : notificationsToShow.length === 0 ? (
+              <div className="text-sm text-[#8D8D8D]">
+                알림이 존재하지 않습니다.
+              </div>
+            ) : (
+              <ul className="space-y-2">
+                {notificationsToShow.map((n, i) => (
+                  <li
+                    key={i}
+                    className="flex justify-between items-center px-[10px] py-[8px] hover:bg-[#F1F8EF] rounded-[12px]"
+                  >
+                    <div className="flex flex-col">
+                      <span className="text-[#2C2C2C] text-[14px] font-medium leading-[145%]">
+                        {n.message}
+                      </span>
+                      <span className="text-[#8D8D8D] text-[12px] font-normal leading-[145%]">
+                        {n.time}
+                      </span>
+                    </div>
+                    <div className="w-[15px] h-[15px] bg-[#90D26D] rounded-full flex-shrink-0" />
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         )}
 
         {/* 프로필 */}
         <div
-          onClick={goToMyPage}
+          onClick={() => navigate("/mypage/myprofile")}
           className="flex gap-2 md:gap-3 items-center min-w-0 cursor-pointer"
         >
-          <div className="w-10 h-10 bg-gray-300 rounded-full shrink-0" />
+          <div className="w-10 h-10 rounded-full shrink-0 overflow-hidden bg-gray-300">
+            <img
+              src={me?.profileImageUrl}
+              alt={me?.nickname ? `${me.nickname}의 프로필` : "기본 프로필"}
+              className="w-full h-full object-cover"
+            />
+          </div>
           <div className="flex flex-col justify-center min-w-0">
             <div className="flex items-center gap-3">
               <span className="text-sm md:text-base font-semibold text-[#2C2C2C] truncate">
-                {userProfile.username}
+                {me?.nickname || (profilePending ? "불러오는 중..." : "")}
               </span>
-              {isAdmin && (
-                <FaCircleCheck size={16} color="#90D26D" /> // 운영자일 때만 체크표시
-              )}
             </div>
             <span className="text-xs md:text-sm text-[#8D8D8D] truncate">
-              {userProfile.bio}
+              {me?.description ?? ""}
             </span>
           </div>
         </div>

--- a/src/pages/Auth/LoginPage.tsx
+++ b/src/pages/Auth/LoginPage.tsx
@@ -67,20 +67,21 @@ const LoginPage = () => {
     login(
       { email, password },
       {
-        onSuccess: async (result) => {
-          if (result?.nickname) {
-            localStorage.setItem("nickname", result.nickname);
-          }
-
-          // 로그인 직후 프로필 데이터 캐시에 저장
+        onSuccess: async () => {
           try {
             const profile = await getMyProfile();
+
+            // localStorage에 닉네임 + 프로필 이미지 저장
+            localStorage.setItem("nickname", profile.nickname);
+            localStorage.setItem("profileImageUrl", profile.profileImageUrl ?? "");
+
+            // React Query 캐시에도 저장
             qc.setQueryData(QK.me, profile);
+
+            navigate("/home");
           } catch (err) {
             console.error("프로필 불러오기 실패:", err);
           }
-
-          navigate("/home");
         },
         onError: (err) => {
           setAlertMessage(err.message || "아이디 또는 비밀번호가 올바르지 않습니다.");


### PR DESCRIPTION

- 저번 파일 헤더 컴포넌트 다시 커밋
- 로컬스토리지에 닉네임 말고 프로필 이미지 저장되게 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 헤더가 실제 사용자 프로필과 알림 미리보기를 자동으로 불러와 표시합니다(뱃지로 미확인 수 표시, 로딩/빈 상태 문구, 알림 목록 제공).
  * 프로필 아바타, 닉네임/소개 표시 및 마이페이지로 이동 기능 추가.
  * 관리 버튼 표시/레이블/경로/클릭 핸들러 커스터마이즈 지원 및 경로 자동 결정.

* 리팩터링
  * 헤더의 더미/프롭 기반 데이터 제거 후 API 기반 데이터 흐름으로 전환, 레이아웃/모달 동작 정리.
  * 로그인 성공 후 프로필을 조회하여 로컬 저장소와 캐시를 갱신하고 홈으로 이동하는 플로우로 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->