### PR TITLE
[fix] 페이지 오류 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -161,13 +161,21 @@ const Header = ({
           onClick={() => navigate("/mypage/myprofile")}
           className="flex gap-2 md:gap-3 items-center min-w-0 cursor-pointer"
         >
-          <div className="w-10 h-10 rounded-full shrink-0 overflow-hidden bg-gray-300">
-            <img
-              src={me?.profileImageUrl}
-              alt={me?.nickname ? `${me.nickname}의 프로필` : "기본 프로필"}
-              className="w-full h-full object-cover"
-            />
+          <div className="w-10 h-10 rounded-full shrink-0 overflow-hidden bg-gray-300 flex items-center justify-center">
+            {me?.profileImageUrl ? (
+              <img
+                src={me.profileImageUrl}
+                alt={me?.nickname ? `${me.nickname}의 프로필` : "기본 프로필"}
+                className="w-full h-full object-cover"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = "none";
+                }}
+              />
+            ) : (
+              <span className="text-gray-400 text-lg">+</span>
+            )}
           </div>
+
           <div className="flex flex-col justify-center min-w-0">
             <div className="flex items-center gap-3">
               <span className="text-sm md:text-base font-semibold text-[#2C2C2C] truncate">

--- a/src/pages/Main/Info/My/MyGroupPage.tsx
+++ b/src/pages/Main/Info/My/MyGroupPage.tsx
@@ -8,8 +8,8 @@ import type { ClubItem } from "../../../../types/My/member";
 const MyGroupPage = () => {
   const [showConfirmModal, setShowConfirmModal] = useState(false); 
   const [showResultModal, setShowResultModal] = useState(false);  
-  const [showErrorModal, setShowErrorModal] = useState(false); // 에러 모달
-  const [errorMessage, setErrorMessage] = useState("");         // 에러 메시지
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
   const [errorImages, setErrorImages] = useState<Record<number, boolean>>({});
   const [isLeaving, setIsLeaving] = useState(false); 
@@ -27,7 +27,7 @@ const MyGroupPage = () => {
 
   // 탈퇴 실행
   const confirmLeaveGroup = () => {
-    if (!selectedGroupId || isLeaving) return; // 이미 요청 중이면 중단
+    if (!selectedGroupId || isLeaving) return;
     setIsLeaving(true);
 
     leaveClubMutation.mutate(selectedGroupId, {
@@ -35,7 +35,7 @@ const MyGroupPage = () => {
         setIsLeaving(false);
         setSelectedGroupId(null);
         setShowConfirmModal(false);
-        setShowResultModal(true); // 성공 모달
+        setShowResultModal(true);
         refetch();
       },
       onError: (error: any) => {
@@ -74,83 +74,92 @@ const MyGroupPage = () => {
 
       <div className="flex-1 flex flex-col pt-[96px] overflow-hidden">
         <main className="flex-1 overflow-y-auto">
-          <div className="px-4 md:px-10 py-8 space-y-4 flex flex-col items-center">
-            {data?.clubList?.map((group: ClubItem) => {
-              const imgUrl = getImageUrl(group.profileImageUrl);
-              const isErrorImage = errorImages[group.clubId] || !imgUrl;
+          <div className="px-4 md:px-10 py-8 flex flex-col items-center min-h-full">
 
-              return (
-                <div
-                  key={group.clubId}
-                  className="w-full flex flex-col md:flex-row justify-between bg-white border border-[#EAE5E2] rounded-[16px] px-4 md:px-6 py-4 shadow-sm cursor-pointer hover:bg-[#FAFAFA]"
-                  onClick={() => handleGroupClick(group.clubId)}
-                >
-                  {/* 왼쪽: 프로필 사진 + 텍스트 */}
-                  <div className="flex gap-4 md:gap-6">
-                    <div className="bg-gray-200 rounded-[16px] overflow-hidden w-[80px] h-[100px] md:w-[119px] md:h-[119px] flex-shrink-0 flex items-center justify-center">
-                      {!isErrorImage ? (
-                        <img
-                          src={imgUrl!}
-                          alt={group.name}
-                          className="w-full h-full object-cover"
-                          onError={() =>
-                            setErrorImages((prev) => ({ ...prev, [group.clubId]: true }))
-                          }
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm">
-                          No Image
-                        </div>
-                      )}
-                    </div>
+            {/* 모임 목록 */}
+            <div className="w-full space-y-4 flex flex-col">
+              {data?.clubList?.map((group: ClubItem) => {
+                const imgUrl = getImageUrl(group.profileImageUrl);
+                const isErrorImage = errorImages[group.clubId] || !imgUrl;
 
-                    <div className="flex flex-col justify-between">
-                      <div>
-                        <div className="flex gap-2 mb-2 md:mb-3">
-                          <span className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2">
-                            7기
-                          </span>
-                          {group.category.map((cat, idx) => (
-                            <span
-                              key={idx}
-                              className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2"
-                            >
-                              {cat}
+                return (
+                  <div
+                    key={group.clubId}
+                    className="w-full flex flex-col md:flex-row justify-between bg-white border border-[#EAE5E2] rounded-[16px] px-4 md:px-6 py-4 shadow-sm cursor-pointer hover:bg-[#FAFAFA]"
+                    onClick={() => handleGroupClick(group.clubId)}
+                  >
+                    {/* 왼쪽: 프로필 사진 + 텍스트 */}
+                    <div className="flex gap-4 md:gap-6">
+                      <div className="bg-gray-200 rounded-[16px] overflow-hidden w-[80px] h-[100px] md:w-[119px] md:h-[119px] flex-shrink-0 flex items-center justify-center">
+                        {!isErrorImage ? (
+                          <img
+                            src={imgUrl!}
+                            alt={group.name}
+                            className="w-full h-full object-cover"
+                            onError={() =>
+                              setErrorImages((prev) => ({ ...prev, [group.clubId]: true }))
+                            }
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm">
+                            No Image
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="flex flex-col justify-between">
+                        <div>
+                          <div className="flex gap-2 mb-2 md:mb-3">
+                            <span className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2">
+                              7기
                             </span>
-                          ))}
+                            {group.category.map((cat, idx) => (
+                              <span
+                                key={idx}
+                                className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2"
+                              >
+                                {cat}
+                              </span>
+                            ))}
+                          </div>
+                          <p className="text-[#2C2C2C] text-[16px] md:text-[18px] font-semibold break-keep">
+                            {group.name}
+                          </p>
+                          <p className="text-[#5C5C5C] text-[13px] md:text-[14px] break-words">
+                            {group.description}
+                          </p>
                         </div>
-                        <p className="text-[#2C2C2C] text-[16px] md:text-[18px] font-semibold break-keep">
-                          {group.name}
-                        </p>
-                        <p className="text-[#5C5C5C] text-[13px] md:text-[14px] break-words">
-                          {group.description}
-                        </p>
                       </div>
                     </div>
-                  </div>
 
-                  {/* 오른쪽: 탈퇴 버튼 */}
-                  <div className="flex justify-end md:items-end mt-4 md:mt-0">
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedGroupId(group.clubId);
-                        setShowConfirmModal(true);
-                      }}
-                      disabled={isLeaving} // 요청 중이면 버튼 비활성화
-                      className={`text-[#5C5C5C] border border-[#EAE5E2] rounded-full w-[90px] md:w-[105px] h-[32px] md:h-[35px] text-sm mt-auto 
-                        ${isLeaving ? "opacity-50 cursor-not-allowed" : "hover:bg-[#90D26D] hover:text-white"}`}
-                    >
-                      탈퇴하기
-                    </button>
+                    {/* 오른쪽: 탈퇴 버튼 */}
+                    <div className="flex justify-end md:items-end mt-4 md:mt-0">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedGroupId(group.clubId);
+                          setShowConfirmModal(true);
+                        }}
+                        disabled={isLeaving}
+                        className={`text-[#5C5C5C] border border-[#EAE5E2] rounded-full w-[90px] md:w-[105px] h-[32px] md:h-[35px] text-sm mt-auto 
+                          ${isLeaving ? "opacity-50 cursor-not-allowed" : "hover:bg-[#90D26D] hover:text-white"}`}
+                      >
+                        탈퇴하기
+                      </button>
+                    </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
 
-            {isFetching && (
-              <p className="text-center text-gray-400">불러오는 중...</p>
-            )}
+              {isFetching && (
+                <p className="text-center text-gray-400">불러오는 중...</p>
+              )}
+            </div>
+
+            {/* 하단 고정 문구 */}
+            <p className="mt-auto text-center text-gray-500 py-4">
+              모임이 더 이상 없습니다.
+            </p>
           </div>
         </main>
       </div>


### PR DESCRIPTION
- 내 모임 페이지 모임이 존재하지 않을 경우 문구 추가
- 헤더 기본 이미지 회색 원으로 수정
- 마이 프로필 페이지 사진 선택 안 할 시에 전에 저장된 정보 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 프로필 사진을 기본 이미지로 되돌리기 지원 및 클릭 가능한 아바타·이미지 업로드 영역 추가
  - 내 모임 목록에서 카드 클릭 시 모임 홈으로 이동

- 개선
  - 헤더 아바타 표시 로직 및 정렬 개선(+ 플레이스홀더, 대체 텍스트 유지)
  - 내 모임 목록 레이아웃 재구성 및 하단 “모임이 더 이상 없습니다.” 안내 추가
  - 키워드/카테고리 처리 정리로 편집 흐름 안정화

- 버그 수정
  - 누락·오류 프로필/모임 이미지 표시 문제 개선(에러 시 숨김, 이미지 URL 정규화)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->