### PR TITLE
[fix] 북클럽 검색페이지 북클럽 링크 오류 해결

### DIFF
--- a/src/components/SearchClub/ClubCard.tsx
+++ b/src/components/SearchClub/ClubCard.tsx
@@ -123,6 +123,36 @@ export default function ClubCard({
   // 참여자 유형을 이름으로 변환
   const participantNames = participantTypes.map(type => PARTICIPANT_TYPES[type as keyof typeof PARTICIPANT_TYPES] || type);
 
+  const formatUrlForDisplay = (rawUrl: string, maxLength: number = 50): string => {
+    if (!rawUrl) return '';
+    if (rawUrl.length <= maxLength) return rawUrl;
+
+    let parsed: URL | null = null;
+    try {
+      parsed = new URL(rawUrl);
+    } catch {
+      try {
+        parsed = new URL(`https://${rawUrl}`);
+      } catch {
+        parsed = null;
+      }
+    }
+
+    if (parsed) {
+      const origin = `${parsed.protocol}//${parsed.host}`;
+      const pathSegments = parsed.pathname.split('/').filter(Boolean);
+      const lastSegment = pathSegments.length > 0 ? pathSegments[pathSegments.length - 1] : '';
+      const tail = `${lastSegment}${parsed.search || ''}${parsed.hash || ''}`;
+      const composed = `${origin}/…/${tail}`;
+      if (composed.length <= maxLength) return composed;
+    }
+
+    const keep = Math.max(5, Math.floor((maxLength - 3) / 2));
+    const head = rawUrl.slice(0, keep);
+    const tail = rawUrl.slice(-keep);
+    return `${head}…${tail}`;
+  };
+
   return (
     <div
       className={`
@@ -256,15 +286,15 @@ export default function ClubCard({
                 flex flex-col gap-[10px]
               ">
                 {kakao ? (
-                  <a href={kakao} target="_blank" rel="noopener noreferrer">
-                    카카오톡 링크 바로가기
+                  <a href={kakao} target="_blank" rel="noopener noreferrer" title={kakao}>
+                    {formatUrlForDisplay(kakao)}
                   </a>
                 ) : (
                   <span className="no-underline text-[#8D8D8D]">등록된 카카오톡 링크가 없습니다.</span>
                 )}
                 {insta ? (
-                  <a href={insta} target="_blank" rel="noopener noreferrer">
-                    인스타그램 링크 바로가기
+                  <a href={insta} target="_blank" rel="noopener noreferrer" title={insta}>
+                    {formatUrlForDisplay(insta)}
                   </a>
                 ) : (
                   <span className="no-underline text-[#8D8D8D]">등록된 인스타그램 링크가 없습니다.</span>

--- a/src/pages/Main/ClubSearchPage.tsx
+++ b/src/pages/Main/ClubSearchPage.tsx
@@ -48,7 +48,6 @@ export default function ClubSearchPage(): React.ReactElement {
     <>
       <div className="absolute left-[315px] right-[42px] opacity-100">
         <Header pageTitle={'모임 검색하기'}
-          notifications={[]}
           customClassName="mt-[30px]"
           />
 
@@ -122,6 +121,8 @@ export default function ClubSearchPage(): React.ReactElement {
                     participantTypes={club.participantTypes}
                     region={club.region}
                     logoUrl={club.profileImageUrl}
+                    insta={club.insta}
+                    kakao={club.kakao}
                     isMember={member}
                     onJoinRequest={handleJoinRequest}
                   />


### PR DESCRIPTION
# 제목 [fix] 북클럽 검색페이지 북클럽 링크 오류 해결

## 작업내용

1. 인스타, 카카오 링크 response 받아와도 없다고 뜨는 문제 해결
2. 인스타, 카카오 링크 뜨는 부분 UI 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 동아리 카드에 Instagram·KakaoTalk 링크 표시. 클릭 가능하며, 축약된 표시 텍스트와 전체 URL 툴팁 제공.

* 스타일
  * 긴 URL을 자동으로 간결화해 링크 가독성 개선(최대 길이 내 축약).
  * 동아리 검색 페이지 헤더에서 알림 표시 제거로 인터페이스 단순화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->