### PR TITLE
[chore] 북클럽 홈화면 세부사항 수정

### DIFF
--- a/src/pages/BookClub/BookClubHomePage.tsx
+++ b/src/pages/BookClub/BookClubHomePage.tsx
@@ -112,7 +112,7 @@ export default function BookClubHomePage(): React.ReactElement {
           <section className="w-full h-[376px] mb-[60px]">
             <div className="flex justify-between items-center mb-[20px]">
               <h2 className="text-[18px] font-semibold">책 이야기</h2>
-              <Link to={`/bookclub/${numericClubId}/admin`} className="text-[14px] text-[#8D8D8D] mr-3 hover:underline">
+              <Link to={`/bookclub/${numericClubId}/admin`} className="text-[14px] text-[#8D8D8D] mr-11 hover:underline">
                   + 더보기
               </Link>
             </div>

--- a/src/pages/BookClub/BookClubHomePage.tsx
+++ b/src/pages/BookClub/BookClubHomePage.tsx
@@ -112,7 +112,7 @@ export default function BookClubHomePage(): React.ReactElement {
           <section className="w-full h-[376px] mb-[60px]">
             <div className="flex justify-between items-center mb-[20px]">
               <h2 className="text-[18px] font-semibold">책 이야기</h2>
-              <Link to={`/bookclub/${bookclubId}/notifications`} className="text-[14px] text-[#8D8D8D] mr-3 hover:underline">
+              <Link to={`/bookclub/${numericClubId}/admin`} className="text-[14px] text-[#8D8D8D] mr-3 hover:underline">
                   + 더보기
               </Link>
             </div>


### PR DESCRIPTION
1. 책이야기 라우팅 경로 수정
2. 더보기 버튼 위치 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - “책 이야기” 섹션의 “+ 더보기” 링크가 숫자형 클럽 ID를 사용하여 관리자 페이지(/bookclub/{id}/admin)로 이동하도록 경로를 변경했습니다. 기존 공지사항 경로 대신 관리자 경로로 연결되며, 라벨과 섹션 구조, 기타 동작은 동일합니다.

- Style
  - “+ 더보기” 링크의 오른쪽 여백을 mr-3에서 mr-11로 확대해 가로 간격을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->