### PR TITLE
[style] 사이드바 폰트 수정

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -358,7 +358,11 @@ const Sidebar = () => {
       />
       <div className="flex flex-col justify-center">
         <span
-          className={`text-4xl font-bold font-blackHanSans break-words truncate text-[#3D4C35]`}
+          style={{
+            fontFamily: "'Black Han Sans', sans-serif",
+            fontSize: bookclubId ? "2.25rem" : "3rem",
+          }}
+          className="break-words truncate text-[#3D4C35]"
           title={bookclubName}
           onClick={() =>
             navigate(bookclubId ? `/bookclub/${bookclubId}/home` : "/home")

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Black+Han+Sans&display=swap");
 @import "tailwindcss";
 
 html {


### PR DESCRIPTION
<img width="353" height="505" alt="image" src="https://github.com/user-attachments/assets/0e614b9a-b515-4a35-8d16-6c8811d93c54" />

사이드바 폰트 수정했습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 사이드바 제목 타이포그래피 개선: ‘Black Han Sans’ 폰트 적용, 북클럽 ID 유무에 따라 글자 크기 2.25rem/3rem로 조정. 가독성 향상, 동작 변화 없음.
  * 전역 스타일에 Google Fonts(Black Han Sans) 추가로 제목 폰트 일관성 강화. 기존 Tailwind 설정 및 기타 CSS는 유지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->