### PR TITLE
[style] 공지사항 상세페이지 스타일 수정

### DIFF
--- a/src/components/BookClub/GeneralNoticeContent.tsx
+++ b/src/components/BookClub/GeneralNoticeContent.tsx
@@ -7,7 +7,7 @@ interface GeneralNoticeContentProps {
 
 export default function GeneralNoticeContent({ data }: GeneralNoticeContentProps): React.ReactElement {
   return (
-    <div className="w-[1080px] h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px]">
+    <div className="w-[1080px] h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] ml-1">
       {/* 제목 영역 */}
         <div className="w-full h-[57px] border-b-[2px] border-[#EEEEEE] mb-[20px]">
           <h3 className="pt-[10px] pb-[20px] pl-[23.5px] font-pretendard font-semibold text-[20px] leading-[145%] tracking-[-0.1%] text-[#000000] ">

--- a/src/components/BookClub/VoteNoticeContent.tsx
+++ b/src/components/BookClub/VoteNoticeContent.tsx
@@ -270,7 +270,7 @@ export default function VoteNoticeContent({ data, registerBackBlocker }: VoteNot
   return (
     <div>
       {/* 메인 콘텐츠 영역 */}
-      <div className="w-[1080px] min-h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] mx-auto">
+      <div className="w-[1080px] min-h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] ml-1">
         
         {/* 제목 영역 */}
         <div className="w-full h-[57px] border-b-[2px] border-[#EEEEEE] mb-[20px]">


### PR DESCRIPTION
# 제목 [style] 공지사항 상세페이지 스타일 수정

## 작업내용

1. 일반 공지사항, 투표 공지사항 메인컨텐츠 위치 조정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 북클럽 일반 공지 및 투표 공지 콘텐츠의 컨테이너 좌측 여백을 소폭 추가해(약 0.25rem) 콘텐츠가 약간 왼쪽으로 정렬되도록 조정했습니다. 목록형 콘텐츠의 시각적 정렬과 가독성이 개선됩니다.
  * 너비, 패딩, 테두리, 동작 등 기타 스타일과 기능에는 변경이 없으며, 레이아웃상의 미세한 시각적 조정만 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->