### PR TITLE
[feat] 책 이야기 무한스크롤 추가 및 스타일 일부 수정 #292

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -79,115 +79,115 @@ const Sidebar = () => {
 
   const menus: Menu[] = bookclubId
     ? [
-      {
-        name: bookclubName,
-        path: `/bookclub/${bookclubId}/home`,
-        icon: { green: homeGreen, gray: homeGray },
-        submenus: [
-          { name: "공지사항", path: `/bookclub/${bookclubId}/notices` },
-          { name: "책장", path: `/bookclub/${bookclubId}/shelf` },
-          {
-            name: "모임",
-            path: "#",
-            submenus: [
-              {
-                name: "모임 전체보기",
-                path: `/bookclub/${bookclubId}/meeting`,
-              },
-              { name: "이번 모임 바로가기", path: `/bookclub/this` },
-            ],
-          },
-          {
-            name: "책 추천",
-            path: "#",
-            submenus: [
-              {
-                name: "책 추천 전체보기",
-                path: `/bookclub/${bookclubId}/recommend`,
-              },
-              {
-                name: "책 추천 하기",
-                path: `/bookclub/${bookclubId}/recommend/search`,
-              },
-            ],
-          },
-        ],
-      },
-      {
-        name: "책 검색하기",
-        icon: { green: searchGreen, gray: searchGray },
-        submenus: [
-          { name: "통합검색", path: "/booksearch" },
-          { name: "국내도서", path: "/booksearch1" },
-          { name: "전자책", path: "/booksearch2" },
-        ],
-      },
-      {
-        name: "책 이야기",
-        icon: { green: bookstoryGreen, gray: bookstoryGray },
-        submenus: [
-          { name: "전체보기", path: "/bookstory" },
-          { name: "내 책 이야기", path: "/bookstory/my" },
-        ],
-      },
-      {
-        name: "마이페이지",
-        icon: { green: mypageGreen, gray: mypageGray },
-        submenus: [
-          { name: "내 모임", path: "/mypage/group" },
-          { name: "내 책 이야기", path: "/mypage/story" },
-          { name: "내 알림", path: "/mypage/notification" },
-          { name: "내 구독", path: "/mypage/subscription" },
-        ],
-      },
-    ]
+        {
+          name: bookclubName,
+          path: `/bookclub/${bookclubId}/home`,
+          icon: { green: homeGreen, gray: homeGray },
+          submenus: [
+            { name: "공지사항", path: `/bookclub/${bookclubId}/notices` },
+            { name: "책장", path: `/bookclub/${bookclubId}/shelf` },
+            {
+              name: "모임",
+              path: "#",
+              submenus: [
+                {
+                  name: "모임 전체보기",
+                  path: `/bookclub/${bookclubId}/meeting`,
+                },
+                { name: "이번 모임 바로가기", path: `/bookclub/this` },
+              ],
+            },
+            {
+              name: "책 추천",
+              path: "#",
+              submenus: [
+                {
+                  name: "책 추천 전체보기",
+                  path: `/bookclub/${bookclubId}/recommend`,
+                },
+                {
+                  name: "책 추천 하기",
+                  path: `/bookclub/${bookclubId}/recommend/search`,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "책 검색하기",
+          icon: { green: searchGreen, gray: searchGray },
+          submenus: [
+            { name: "통합검색", path: "/booksearch" },
+            { name: "국내도서", path: "/booksearch1" },
+            { name: "전자책", path: "/booksearch2" },
+          ],
+        },
+        {
+          name: "책 이야기",
+          icon: { green: bookstoryGreen, gray: bookstoryGray },
+          submenus: [
+            { name: "전체보기", path: "/bookstory" },
+            { name: "내 책 이야기", path: "/bookstory/my" },
+          ],
+        },
+        {
+          name: "마이페이지",
+          icon: { green: mypageGreen, gray: mypageGray },
+          submenus: [
+            { name: "내 모임", path: "/mypage/group" },
+            { name: "내 책 이야기", path: "/mypage/story" },
+            { name: "내 알림", path: "/mypage/notification" },
+            { name: "내 구독", path: "/mypage/subscription" },
+          ],
+        },
+      ]
     : [
-      {
-        name: "홈",
-        path: "/home",
-        icon: { green: homeGreen, gray: homeGray },
-        submenus: [],
-      },
-      {
-        name: "독서 모임",
-        icon: { green: bookclubGreen, gray: bookclubGray },
-        submenus: [
-          { name: "내 모임 바로가기", path: "#", isModal: true },
-          { name: "모임 검색하기", path: "/searchClub" },
-          { name: "모임 생성하기", path: "/createClub" },
-        ],
-      },
-      {
-        name: "책 검색하기",
-        path: "/booksearch",
-        icon: { green: searchGreen, gray: searchGray },
-        submenus: [
-          { name: "통합검색", path: "/booksearch" },
-          { name: "국내도서", path: "/booksearch1" },
-          { name: "전자책", path: "/booksearch2" },
-        ],
-      },
-      {
-        name: "책 이야기",
-        path: "/bookstory",
-        icon: { green: bookstoryGreen, gray: bookstoryGray },
-        submenus: [
-          { name: "전체보기", path: "/bookstory" },
-          { name: "내 책 이야기", path: "/bookstory/my" },
-        ],
-      },
-      {
-        name: "마이페이지",
-        path: "/mypage",
-        icon: { green: mypageGreen, gray: mypageGray },
-        submenus: [
-          { name: "내 모임", path: "/mypage/group" },
-          { name: "내 책 이야기", path: "/mypage/story" },
-          { name: "내 알림", path: "/mypage/notification" },
-          { name: "내 구독", path: "/mypage/subscription" },
-        ],
-      },
-    ];
+        {
+          name: "홈",
+          path: "/home",
+          icon: { green: homeGreen, gray: homeGray },
+          submenus: [],
+        },
+        {
+          name: "독서 모임",
+          icon: { green: bookclubGreen, gray: bookclubGray },
+          submenus: [
+            { name: "내 모임 바로가기", path: "#", isModal: true },
+            { name: "모임 검색하기", path: "/searchClub" },
+            { name: "모임 생성하기", path: "/createClub" },
+          ],
+        },
+        {
+          name: "책 검색하기",
+          path: "/booksearch",
+          icon: { green: searchGreen, gray: searchGray },
+          submenus: [
+            { name: "통합검색", path: "/booksearch" },
+            { name: "국내도서", path: "/booksearch1" },
+            { name: "전자책", path: "/booksearch2" },
+          ],
+        },
+        {
+          name: "책 이야기",
+          path: "/bookstory",
+          icon: { green: bookstoryGreen, gray: bookstoryGray },
+          submenus: [
+            { name: "전체보기", path: "/bookstory" },
+            { name: "내 책 이야기", path: "/bookstory/my" },
+          ],
+        },
+        {
+          name: "마이페이지",
+          path: "/mypage",
+          icon: { green: mypageGreen, gray: mypageGray },
+          submenus: [
+            { name: "내 모임", path: "/mypage/group" },
+            { name: "내 책 이야기", path: "/mypage/story" },
+            { name: "내 알림", path: "/mypage/notification" },
+            { name: "내 구독", path: "/mypage/subscription" },
+          ],
+        },
+      ];
 
   const toggleMenu = (menuName: string) => {
     setOpenMenus((prev) => {
@@ -212,12 +212,11 @@ const Sidebar = () => {
     const currentPath = location.pathname;
     const activeColor = "#3D4C35";
     const inactiveColor = "#AAAAAA";
+
     if (subPath) {
-      if (subPath === "/bookstory" || subPath === "/booksearch") {
-        return currentPath === subPath ? activeColor : inactiveColor;
-      }
-      return currentPath.startsWith(subPath) ? activeColor : inactiveColor;
+      return currentPath === subPath ? activeColor : inactiveColor;
     }
+
     return isTopMenuActive(menu) ? activeColor : inactiveColor;
   };
 
@@ -362,7 +361,7 @@ const Sidebar = () => {
             fontFamily: "'Black Han Sans', sans-serif",
             fontSize: bookclubId ? "2.25rem" : "3rem",
           }}
-          className="break-words truncate text-[#3D4C35]"
+          className="max-w-[160px] whitespace-nowrap overflow-hidden text-ellipsis text-[#3D4C35]"
           title={bookclubName}
           onClick={() =>
             navigate(bookclubId ? `/bookclub/${bookclubId}/home` : "/home")
@@ -406,8 +405,9 @@ const Sidebar = () => {
                   to={path ?? submenus[0]?.path ?? "#"}
                   end
                   style={{ color: getMenuTextColor(menu) }}
-                  className={`flex items-center gap-3 py-2 pl-3 pr-4 w-full rounded-r-lg cursor-pointer hover:bg-[#DDEED6] ${isTopMenuActive(menu) ? "border-l-4 border-[#93C27C]" : ""
-                    }`}
+                  className={`flex items-center gap-3 py-2 pl-3 pr-4 w-full rounded-r-lg cursor-pointer hover:bg-[#DDEED6] ${
+                    isTopMenuActive(menu) ? "border-l-4 border-[#93C27C]" : ""
+                  }`}
                   onClick={() => {
                     if (submenus.length > 0) toggleMenu(name);
                   }}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -413,7 +413,10 @@ const Sidebar = () => {
                   }}
                 >
                   <img src={getIconSrc(menu)} className="w-5 h-5" />
-                  <span className="text-[18px] font-medium font-pretendard">
+                  <span
+                    className="text-[18px] font-medium whitespace-nowrap overflow-hidden text-ellipsis block w-[9rem]"
+                    title={name} // hover시 전체 이름 확인 가능
+                  >
                     {name}
                   </span>
                 </NavLink>

--- a/src/pages/Main/BookStory/BookStoryHomePage.tsx
+++ b/src/pages/Main/BookStory/BookStoryHomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import BookStoryCard from "../../../components/BookStory/BookStoryCard";
 import { LayoutGrid, List, Pencil } from "lucide-react";
 import Header from "../../../components/Header";
@@ -23,26 +23,35 @@ export default function BookStoryHomePage() {
   const [stories, setStories] = useState<BookStoryResponseDto[]>([]);
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [loading, setLoading] = useState(false);
-  const tabContainerRef = useRef<HTMLDivElement>(null);
+  const [cursor, setCursor] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState(true);
 
-  useEffect(() => {
-    const loadStoriesAndClubs = async () => {
-      if (!tabs[activeTab]) return;
+  const tabContainerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 데이터 로드 함수
+  const loadStories = useCallback(
+    async (reset = false) => {
+      if (!tabs[activeTab] || loading) return;
+
+      const { scope, clubId } = tabs[activeTab];
+      if (scope !== "ALL" && !reset) return; // 무한 스크롤은 ALL에서만
+
       setLoading(true);
       try {
-        const { scope, clubId } = tabs[activeTab];
-        const data = await fetchBookStories({ scope, clubId });
+        const data = await fetchBookStories({
+          scope,
+          clubId,
+          cursorId: reset ? null : cursor,
+        });
 
-        const filteredStories =
-          scope === "FOLLOWING"
-            ? (data.bookStoryResponses || []).filter(
-                (story) => story.authorInfo?.following
-              )
-            : data.bookStoryResponses || [];
+        const newStories = data.bookStoryResponses || [];
+        setStories((prev) => (reset ? newStories : [...prev, ...newStories]));
+        setCursor(data.nextCursor ?? null);
+        setHasNext(data.hasNext ?? false);
 
-        setStories(filteredStories);
-
-        if (data.memberClubList?.clubList?.length > 0) {
+        // 새로운 클럽 탭 추가 (처음 한 번만)
+        if (reset && data.memberClubList?.clubList?.length > 0) {
           setTabs((prev) => {
             const existingClubIds = new Set(prev.map((tab) => tab.clubId));
             const newClubs = data.memberClubList.clubList.filter(
@@ -64,10 +73,32 @@ export default function BookStoryHomePage() {
       } finally {
         setLoading(false);
       }
+    },
+    [tabs, activeTab, cursor, loading]
+  );
+
+  // 탭 변경 시 초기화 후 데이터 불러오기
+  useEffect(() => {
+    setStories([]);
+    setCursor(null);
+    setHasNext(true);
+    loadStories(true);
+  }, [activeTab]);
+
+  // 무한 스크롤 감지
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!containerRef.current || loading || !hasNext) return;
+      const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+      if (scrollHeight - scrollTop - clientHeight < 200) {
+        loadStories();
+      }
     };
 
-    loadStoriesAndClubs();
-  }, [activeTab]);
+    const container = containerRef.current;
+    container?.addEventListener("scroll", handleScroll);
+    return () => container?.removeEventListener("scroll", handleScroll);
+  }, [loadStories, loading, hasNext]);
 
   const handleToggleLike = (storyId: number, liked: boolean) => {
     setStories((prev) =>
@@ -100,8 +131,12 @@ export default function BookStoryHomePage() {
     <div className="absolute left-[315px] right-[42px] opacity-100">
       <Header pageTitle="책 이야기" customClassName="mt-[30px] pl-4" />
 
-      {/* 탭 */}
-      <div className="overflow-y-auto h-[calc(100vh-80px)] w-full flex-1 pt-[30px] pl-[2px] pr-[30px] bg-[#FFFFFF]">
+      {/* 탭 및 목록 컨테이너 */}
+      <div
+        className="overflow-y-auto h-[calc(100vh-80px)] w-full flex-1 pt-[30px] pl-[2px] pr-[30px] bg-[#FFFFFF]"
+        ref={containerRef}
+      >
+        {/* 탭 */}
         <div className="flex items-center gap-2 mb-6 pl-4">
           <div
             className="flex gap-6 overflow-x-auto scrollbar-hide whitespace-nowrap"
@@ -154,39 +189,34 @@ export default function BookStoryHomePage() {
               : "flex flex-col gap-4 w-full px-4"
           }`}
         >
-          {loading ? (
-            <div>로딩 중...</div>
-          ) : stories.length > 0 ? (
-            stories.map((story) => (
-              <div
-                className="cursor-pointer hover:shadow-lg hover:scale-[1.03]"
-                key={story.bookStoryId}
-                onClick={() =>
-                  navigate(`/bookstory/${story.bookStoryId}/detail`)
-                }
-              >
-                <BookStoryCard
-                  bookStoryId={story.bookStoryId}
-                  imageUrl={story.bookInfo.imgUrl}
-                  profileUrl={story.authorInfo.profileImageUrl}
-                  userName={story.authorInfo.nickname}
-                  isSubscribed={story.authorInfo.following}
-                  title={story.bookStoryTitle}
-                  summary={story.description}
-                  bookTitle={story.bookInfo.title}
-                  author={story.bookInfo.author}
-                  likes={story.likes}
-                  writtenByMe={story.writtenByMe}
-                  likedByMe={story.likedByMe}
-                  viewMode={viewMode}
-                  onToggleLike={handleToggleLike}
-                  onToggleSubscribe={handleToggleSubscribe}
-                />
-              </div>
-            ))
-          ) : (
-            <div>데이터가 없습니다.</div>
-          )}
+          {stories.length === 0 && loading && <div>로딩 중...</div>}
+          {stories.map((story) => (
+            <div
+              className="cursor-pointer hover:shadow-lg hover:scale-[1.03]"
+              key={story.bookStoryId}
+              onClick={() => navigate(`/bookstory/${story.bookStoryId}/detail`)}
+            >
+              <BookStoryCard
+                bookStoryId={story.bookStoryId}
+                imageUrl={story.bookInfo.imgUrl}
+                profileUrl={story.authorInfo.profileImageUrl}
+                userName={story.authorInfo.nickname}
+                isSubscribed={story.authorInfo.following}
+                title={story.bookStoryTitle}
+                summary={story.description}
+                bookTitle={story.bookInfo.title}
+                author={story.bookInfo.author}
+                likes={story.likes}
+                writtenByMe={story.writtenByMe}
+                likedByMe={story.likedByMe}
+                viewMode={viewMode}
+                onToggleLike={handleToggleLike}
+                onToggleSubscribe={handleToggleSubscribe}
+              />
+            </div>
+          ))}
+          {loading && stories.length > 0 && <div>로딩 중...</div>}
+          {!loading && stories.length === 0 && <div>데이터가 없습니다.</div>}
         </div>
       </div>
     </div>

--- a/src/pages/Main/HomePage.tsx
+++ b/src/pages/Main/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import NoticeCard from "../../components/Main/Notices/NoticeCard";
@@ -6,57 +6,110 @@ import BookStoriesCard from "../../components/Main/BookStoriesCard";
 
 import type { BookStoryResponseDto } from "../../types/bookStories";
 import type { NoticeDto } from "../../types/mainNotices";
-
 import { fetchBookStories } from "../../apis/BookStory/bookstories";
+import type { BookStoriesParams } from "../../apis/BookStory/bookstories";
 import { fetchMyClubs } from "../../apis/Main/clubs";
 import { fetchNoticesByClub } from "../../apis/Main/notices";
 
 export default function HomePage() {
   const navigate = useNavigate();
+
   const [bookStories, setBookStories] = useState<BookStoryResponseDto[]>([]);
   const [notices, setNotices] = useState<NoticeDto[]>([]);
   const [loadingBooks, setLoadingBooks] = useState(false);
   const [loadingNotices, setLoadingNotices] = useState(false);
   const [errorBooks, setErrorBooks] = useState<string | null>(null);
+  const [cursorId, setCursorId] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState(true);
 
-  useEffect(() => {
-    // 책 이야기 API
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  // 책 이야기
+  const loadBookStories = useCallback(async () => {
+    if (loadingBooks || !hasNext) return;
     setLoadingBooks(true);
-    fetchBookStories({ scope: "ALL" })
-      .then((data) => setBookStories(data?.bookStoryResponses ?? []))
-      .catch((e) => setErrorBooks(e.message ?? "책 이야기 불러오기 실패"))
-      .finally(() => setLoadingBooks(false));
+    try {
+      const params: BookStoriesParams = { scope: "ALL", cursorId };
+      const data = await fetchBookStories(params);
 
-    // 공지사항 API
+      // 중복 제거
+      setBookStories((prev) => {
+        const newStories = data.bookStoryResponses.filter(
+          (story) => !prev.some((s) => s.bookStoryId === story.bookStoryId)
+        );
+        return [...prev, ...newStories];
+      });
+
+      setCursorId(data.nextCursor);
+      setHasNext(data.hasNext);
+    } catch (e: any) {
+      setErrorBooks(e.message ?? "책 이야기 불러오기 실패");
+    } finally {
+      setLoadingBooks(false);
+    }
+  }, [cursorId, hasNext, loadingBooks]);
+
+  // 초기 책 이야기 로드
+  useEffect(() => {
+    loadBookStories();
+  }, []);
+
+  // 공지사항 로드
+  useEffect(() => {
     setLoadingNotices(true);
     fetchMyClubs()
-      .then((clubs) => {
-        return Promise.all(
+      .then((clubs) =>
+        Promise.all(
           clubs.map(async (club) => {
             const notices = await fetchNoticesByClub(club.clubId);
-            // 각 notice에 clubId 추가
             return notices.map((notice) => ({
               ...notice,
               clubId: club.clubId,
             }));
           })
-        );
-      })
-      .then((noticesArrays) => {
-        const allNotices = noticesArrays.flat();
-        //console.log("allNotices:", allNotices); // << 이거 추가
-
-        setNotices(allNotices);
-      })
+        )
+      )
+      .then((noticesArrays) => setNotices(noticesArrays.flat()))
       .catch((err) => console.error("공지사항 불러오기 실패", err))
       .finally(() => setLoadingNotices(false));
   }, []);
 
+  // 무한 스크롤 Intersection Observer
+  useEffect(() => {
+    if (!scrollContainerRef.current) return;
+
+    const options = {
+      root: scrollContainerRef.current,
+      rootMargin: "100px",
+      threshold: 0,
+    };
+
+    observerRef.current = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          loadBookStories();
+        }
+      });
+    }, options);
+
+    const sentinel = document.getElementById("book-story-sentinel");
+    if (sentinel) observerRef.current.observe(sentinel);
+
+    return () => {
+      if (observerRef.current && sentinel)
+        observerRef.current.unobserve(sentinel);
+    };
+  }, [loadBookStories, bookStories]);
+
   return (
-    <div className="absolute left-[315px] right-[42px] opacity-100 ">
+    <div className="absolute left-[315px] right-[42px] opacity-100">
       <Header pageTitle="책모 홈" customClassName="mt-[30px] pl-2" />
 
-      <div className="overflow-y-auto h-[calc(100vh-80px)] w-full flex-1 pt-[30px] pl-[2px] pr-[30px] bg-[#FFFFFF]">
+      <div
+        ref={scrollContainerRef}
+        className="overflow-y-auto h-[calc(100vh-80px)] w-full flex-1 pt-[30px] pl-[2px] pr-[30px] bg-[#FFFFFF]"
+      >
         {/* 공지사항 */}
         <div className="text-xl font-semibold text-gray-800 mb-4 pl-2">
           공지사항
@@ -88,7 +141,7 @@ export default function HomePage() {
         <div className="text-xl font-semibold text-gray-800 mb-4 pl-2">
           책 이야기
         </div>
-        {loadingBooks && <p>책 이야기 로딩중...</p>}
+        {bookStories.length === 0 && loadingBooks && <p>책 이야기 로딩중...</p>}
         {errorBooks && (
           <p className="text-red-500">책 이야기 에러: {errorBooks}</p>
         )}
@@ -121,6 +174,10 @@ export default function HomePage() {
             );
           })}
         </div>
+
+        {/* 무한 스크롤용 sentinel */}
+        <div id="book-story-sentinel" className="h-2"></div>
+        {loadingBooks && <p>추가 책 이야기 로딩중...</p>}
       </div>
     </div>
   );

--- a/src/pages/Main/HomePage.tsx
+++ b/src/pages/Main/HomePage.tsx
@@ -77,30 +77,30 @@ export default function HomePage() {
 
   // 무한 스크롤 Intersection Observer
   useEffect(() => {
-    if (!scrollContainerRef.current) return;
+    const root = scrollContainerRef.current;
+    if (!root) return;
 
-    const options = {
-      root: scrollContainerRef.current,
-      rootMargin: "100px",
-      threshold: 0,
-    };
+    // 기존 옵저버 정리
+    observerRef.current?.disconnect();
 
-    observerRef.current = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          loadBookStories();
-        }
-      });
-    }, options);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            loadBookStories();
+          }
+        });
+      },
+      { root, rootMargin: "100px", threshold: 0 }
+    );
+
+    observerRef.current = observer;
 
     const sentinel = document.getElementById("book-story-sentinel");
-    if (sentinel) observerRef.current.observe(sentinel);
+    if (sentinel) observer.observe(sentinel);
 
-    return () => {
-      if (observerRef.current && sentinel)
-        observerRef.current.unobserve(sentinel);
-    };
-  }, [loadBookStories, bookStories]);
+    return () => observer.disconnect();
+  }, [loadBookStories]);
 
   return (
     <div className="absolute left-[315px] right-[42px] opacity-100">


### PR DESCRIPTION
## api 연동

- [x] 메인 홈 화면 책 이야기 무한 스크롤
- [x] 책 이야기 전체 보기 무한 스크롤

## 스타일 수정
- [x] 사이드바 헤더 이름 긴 독서모임인 경우 ... 처리
- [x] 사이드바 메뉴 이름 긴 독서모임인 경우 ... 처리 후 hover 시에는 전체 다 보이게 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 홈 및 책 이야기 화면에 커서 기반 무한 스크롤 도입(중복 방지, 초기/추가 로딩 상태, 하단 센티널, 스크롤/관찰자 기반 로드).
  * 책 이야기 탭에 클럽 정보를 기반한 동적 탭 자동 추가 및 페이징 제어(hasNext, cursor).

* **리팩터링**
  * 북클럽 모드 사이드바를 클럽명 단일 상위 메뉴로 재구성하고 하위 메뉴 통합.
  * 메뉴 활성 상태/아이콘 색상 판정 로직 일관화.

* **스타일**
  * 북클럽 헤더·메뉴 라벨 말줄임 처리 및 전체명 툴팁 제공.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->