### PR TITLE
[refactor] 북클럽 편집 페이지 수정

### DIFF
--- a/src/hooks/useUpdateClub.ts
+++ b/src/hooks/useUpdateClub.ts
@@ -16,11 +16,9 @@ export const useUpdateClub = (clubId: number) => {
       // 상세 즉시 재검증 (서버 소스와 동기화 보장)
       queryClient.invalidateQueries({ queryKey: QK_CLUB.detail(clubId) });
       queryClient.refetchQueries({ queryKey: QK_CLUB.detail(clubId) });
-      alert("모임이 성공적으로 수정되었습니다!");
     },
     onError: (error) => {
       console.error("모임 수정 실패:", error);
-      alert("모임 수정에 실패했습니다. 다시 시도해주세요.");
     },
   });
 };

--- a/src/hooks/useUploadImage.ts
+++ b/src/hooks/useUploadImage.ts
@@ -7,19 +7,7 @@ export const useUploadImage = () => {
     mutationFn: uploadImage,
     onError: (error) => {
       console.error('이미지 업로드 실패:', error);
-      const axiosError = error as any;
-      if (axiosError.response?.status === 400) {
-        alert('잘못된 요청입니다.');
-      } else if (axiosError.response?.status === 401) {
-        alert('로그인이 필요한 서비스입니다.');
-      } else {
-        // 일반 Error(message 보유) 우선 안내
-        if (error instanceof Error && error.message) {
-            alert(error.message);
-        } else {
-          alert('이미지 업로드에 실패했습니다. 다시 시도해주세요.');
-        }
-      }
+      // UI 알림은 훅 외부(호출 컴포넌트)에서 처리합니다.
     },
   });
 };

--- a/src/pages/BookClub/Club/ClubEditPage.tsx
+++ b/src/pages/BookClub/Club/ClubEditPage.tsx
@@ -157,7 +157,7 @@ export default function EditClubPage(): React.ReactElement {
       },
       {
         onSuccess: () => {
-          showInfo('모임이 성공적으로 수정되었습니다!');
+          showInfo('모임이 성공적으로 수정되었습니다!', () => navigate(`/bookclub/${numericClubId}/home`));
         },
         onError: () => {
           showInfo('모임 수정에 실패했습니다. 다시 시도해주세요.');

--- a/src/pages/BookClub/Club/ClubEditPage.tsx
+++ b/src/pages/BookClub/Club/ClubEditPage.tsx
@@ -9,6 +9,7 @@ import { useUpdateClub } from '../../../hooks/useUpdateClub';
 import { useUploadImage } from '../../../hooks/useUploadImage';
 import { useIsStaff } from '../../../hooks/BookClub/useIsStaff';
 import { useClubNameValidation } from '../../../hooks/useClubNameValidation';
+import Modal, { type ModalButton } from '../../../components/Modal';
 
 // 카테고리 옵션 (문자열 배열로 변환)
 const BOOK_CATEGORY_OPTIONS = Object.values(BOOK_CATEGORIES);
@@ -66,12 +67,31 @@ export default function EditClubPage(): React.ReactElement {
   const { isValidating, isDuplicate, checkClubName, hasManualCheck, resetValidation } = useClubNameValidation();
   const isNameChanged = useMemo(() => clubName.trim() !== (originalClubName ?? '').trim(), [clubName, originalClubName]);
 
+  // 공통 모달 상태 및 헬퍼
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalTitle, setModalTitle] = useState<React.ReactNode>('');
+  const [modalButtons, setModalButtons] = useState<ModalButton[]>([]);
+
+  const showInfo = (message: React.ReactNode, onConfirm?: () => void) => {
+    setModalTitle(message);
+    setModalButtons([
+      {
+        label: '확인',
+        onClick: () => {
+          setIsModalOpen(false);
+          onConfirm?.();
+        },
+        variant: 'primary',
+      },
+    ]);
+    setIsModalOpen(true);
+  };
+
 
   // 클럽 정보 로드
   useEffect(() => {
     if (!numericClubId || Number.isNaN(numericClubId) || numericClubId <= 0) {
-      alert('잘못된 접근입니다.');
-      navigate('/');
+      showInfo('잘못된 접근입니다.', () => navigate('/'));
       return;
     }
   }, [numericClubId, navigate]);
@@ -79,8 +99,7 @@ export default function EditClubPage(): React.ReactElement {
   // 운영진이 아니면 접근 차단 UX 처리 (백엔드에서도 차단됨)
   useEffect(() => {
     if (isStaff === false) {
-      alert('이 페이지는 운영진만 접근할 수 있습니다.');
-      navigate(`/bookclub/${numericClubId}/home`);
+      showInfo('이 페이지는 운영진만 접근할 수 있습니다.', () => navigate(`/bookclub/${numericClubId}/home`));
     }
   }, [isStaff, navigate, numericClubId]);
 
@@ -103,23 +122,23 @@ export default function EditClubPage(): React.ReactElement {
   // 클럽 수정 핸들러
   const handleUpdateClub = async () => {
     if (!clubName.trim()) {
-      alert('모임 이름을 입력해주세요.');
+      showInfo('모임 이름을 입력해주세요.');
       return;
     }
     if (!clubDescription.trim()) {
-      alert('모임 소개글을 입력해주세요.');
+      showInfo('모임 소개글을 입력해주세요.');
       return;
     }
     if (visibility === null) {
-      alert('공개/비공개 여부를 선택해주세요.');
+      showInfo('공개/비공개 여부를 선택해주세요.');
       return;
     }
     if (selectedCategories.length === 0) {
-      alert('선호하는 독서 카테고리를 선택해주세요.');
+      showInfo('선호하는 독서 카테고리를 선택해주세요.');
       return;
     }
     if (selectedParticipants.length === 0) {
-      alert('모임 참여 대상을 선택해주세요.');
+      showInfo('모임 참여 대상을 선택해주세요.');
       return;
     }
 
@@ -137,6 +156,12 @@ export default function EditClubPage(): React.ReactElement {
         kakao: kakaoLink || undefined,
       },
       {
+        onSuccess: () => {
+          showInfo('모임이 성공적으로 수정되었습니다!');
+        },
+        onError: () => {
+          showInfo('모임 수정에 실패했습니다. 다시 시도해주세요.');
+        },
         onSettled: () => setIsSubmitting(false),
       }
     );
@@ -277,6 +302,7 @@ export default function EditClubPage(): React.ReactElement {
                 },
                 onError: () => {
                   setPreviewImageUrl(null);
+                  showInfo('이미지 업로드에 실패했습니다. 다시 시도해주세요.');
                 }
               });
             }}
@@ -437,6 +463,13 @@ export default function EditClubPage(): React.ReactElement {
           <div className="h-[100px]"></div>
         </div>
       </div>
+      {/* 공통 모달 */}
+      <Modal
+        isOpen={isModalOpen}
+        title={modalTitle}
+        buttons={modalButtons}
+        onBackdrop={() => setIsModalOpen(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
# 제목 [refactor] 북클럽 편집 페이지 수정

## 작업내용

1. alert -> 모달로 수정
2. 라우팅 경로 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 클럽 수정 페이지에 모달 기반 안내/확인 UX를 도입했습니다. 잘못된 접근, 권한 부족, 폼 검증 실패, 업데이트 성공/실패, 이미지 업로드 실패 시 모달로 안내하며 확인 시 적절한 페이지로 이동합니다.
* 리팩터링
  * 공용 훅의 내부 경고/토스트를 제거하고, 화면 단에서 사용자 알림을 처리하도록 변경했습니다. 이로써 알림 방식이 모달로 일원화되어 사용자 경험이 더 일관되고 중복 알림이 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->