### PR TITLE
[feat] 내 책이야기, 내 알림, 내 구독페이지 무한스크롤 구현

### DIFF
--- a/src/hooks/My/useMemberInfinite.ts
+++ b/src/hooks/My/useMemberInfinite.ts
@@ -1,0 +1,38 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import type { InfiniteData } from "@tanstack/react-query";
+import { getMyFollower, getMyFollowing } from "../../apis/My/memberApi";
+import type { FollowResponse } from "../../types/My/member";
+
+export const useMyFollowerInfinite = () => {
+  return useInfiniteQuery<
+    FollowResponse,            // 한 페이지 타입
+    Error,                     // 에러 타입
+    InfiniteData<FollowResponse>, // 전체 데이터 타입 (pages 있음)
+    ["myFollower"],            // queryKey 타입
+    number | null              // pageParam 타입
+  >({
+    queryKey: ["myFollower"],
+    queryFn: ({ pageParam = null }) =>
+      getMyFollower(pageParam as number | null),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.nextCursor : undefined,
+  });
+};
+
+export const useMyFollowingInfinite = () => {
+  return useInfiniteQuery<
+    FollowResponse,
+    Error,
+    InfiniteData<FollowResponse>,
+    ["myFollowing"],
+    number | null
+  >({
+    queryKey: ["myFollowing"],
+    queryFn: ({ pageParam = null }) =>
+      getMyFollowing(pageParam as number | null),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.nextCursor : undefined,
+  });
+};

--- a/src/hooks/My/useMyNotificationsInfinite.ts
+++ b/src/hooks/My/useMyNotificationsInfinite.ts
@@ -1,0 +1,29 @@
+import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
+import { getMyNotifications } from "../../apis/My/memberApi";
+import type { NotificationResponse } from "../../types/My/member";
+
+/**
+ * Infinite loader for My Notifications
+ * - Cursor-based pagination per API contract
+ */
+export function useMyNotificationsInfinite() {
+  return useInfiniteQuery<
+    NotificationResponse, // 개별 페이지 타입
+    Error, // 에러 타입
+    InfiniteData<NotificationResponse>, // 전체 무한 데이터 타입
+    ["notifications", "MY"], // queryKey 타입
+    number | null // cursorId 타입
+  >({
+    queryKey: ["notifications", "MY"],
+    queryFn: ({ pageParam = null }) => {
+      console.log("🔔 Notifications API 요청:", { cursorId: pageParam });
+      return getMyNotifications(pageParam);
+    },
+    initialPageParam: null,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.nextCursor : undefined,
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+  });
+}

--- a/src/pages/Main/Info/My/MyNotificationPage.tsx
+++ b/src/pages/Main/Info/My/MyNotificationPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"; 
+import { useState, useEffect, useRef, useCallback } from "react"; 
 import MyPageHeader from "../../../../components/MyPageHeader";
 import Modal from "../../../../components/Modal"; 
 import type { NotificationItem, NotificationResponse } from "../../../../types/My/member";
@@ -15,14 +15,19 @@ const MyNotificationPage = () => {
     message: "",
   });
 
-  const groupNotificationsByDate = (list: NotificationItem[]) => {
+  // 무한스크롤 상태
+  const [cursorId, setCursorId] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState(true);
+  const [isFetching, setIsFetching] = useState(false);
+
+  const groupNotificationsByDate = (list: NotificationItem[], append = false) => {
     const today = new Date();
     const yesterday = new Date();
     yesterday.setDate(today.getDate() - 1);
 
-    const todayArr: NotificationItem[] = [];
-    const yesterdayArr: NotificationItem[] = [];
-    const weekArr: NotificationItem[] = [];
+    const todayArr: NotificationItem[] = append ? [...todayList] : [];
+    const yesterdayArr: NotificationItem[] = append ? [...yesterdayList] : [];
+    const weekArr: NotificationItem[] = append ? [...weekList] : [];
 
     list.forEach((n) => {
       const created = new Date(n.createdAt);
@@ -51,14 +56,18 @@ const MyNotificationPage = () => {
     setWeekList(weekArr);
   };
 
-  const fetchNotifications = async () => {
+  const fetchNotifications = async (cursor: number | null, append = false) => {
     try {
-      const res: NotificationResponse = await getMyNotifications(null);
-      groupNotificationsByDate(res.notifications);
+      setIsFetching(true);
+      const res: NotificationResponse = await getMyNotifications(cursor);
+
+      groupNotificationsByDate(res.notifications, append);
+
+      setCursorId(res.nextCursor);
+      setHasNext(res.hasNext);
       setIsError(false);
     } catch (err: any) {
       console.error("알림 불러오기 실패:", err);
-      // 400, 404는 모달로 처리
       if (err?.response?.status === 400) {
         setErrorModal({
           open: true,
@@ -70,21 +79,41 @@ const MyNotificationPage = () => {
           message: "알림 정보를 찾을 수 없습니다.",
         });
       } else {
-        // 나머지는 기존 에러 처리
         setIsError(true);
       }
+    } finally {
+      setIsFetching(false);
     }
   };
 
   useEffect(() => {
-    fetchNotifications();
+    fetchNotifications(null, false);
   }, []);
+
+  // IntersectionObserver
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const lastElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (isFetching) return;
+      if (observerRef.current) observerRef.current.disconnect();
+
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNext) {
+          fetchNotifications(cursorId, true);
+        }
+      });
+
+      if (node) observerRef.current.observe(node);
+    },
+    [cursorId, hasNext, isFetching]
+  );
 
   const handleNotificationClick = async (n: NotificationItem) => {
     if (!n.read) {
       try {
         await readNotification(n.notificationId);
-        fetchNotifications();
+        //  읽음 처리 후 다시 불러오기
+        fetchNotifications(null, false);
       } catch (err) {
         console.error("알림 읽음 처리 실패:", err);
       }
@@ -112,6 +141,7 @@ const MyNotificationPage = () => {
     return list.map((n, idx, arr) => (
       <div
         key={n.notificationId}
+        ref={idx === arr.length - 1 ? lastElementRef : null} 
         className={`flex justify-between items-center px-6 py-4 cursor-pointer hover:bg-[#FAFAFA] ${
           idx !== arr.length - 1 ? "border-b border-[#EAE5E2]" : ""
         }`}
@@ -136,7 +166,6 @@ const MyNotificationPage = () => {
 
   return (
     <div className="flex w-full h-screen bg-[#FAFAFA] overflow-hidden">
-      {/* 최상단 에러 메시지 */}
       {isError && (
         <div className="p-6">
           <p className="text-red-500">
@@ -156,7 +185,7 @@ const MyNotificationPage = () => {
                 <h3 className="text-[20px] font-semibold text-[#2C2C2C]">오늘</h3>
                 <button
                   className="text-[#8D8D8D] text-sm hover:underline cursor-pointer"
-                  onClick={() => setShowSettingModal(true)} 
+                  onClick={() => setShowSettingModal(true)}
                 >
                   알림 설정
                 </button>
@@ -174,6 +203,16 @@ const MyNotificationPage = () => {
                 <h3 className="text-[20px] font-semibold text-[#2C2C2C] mb-4">최근 7일</h3>
                 <div className="bg-white rounded-[8px]">{renderList(weekList)}</div>
               </section>
+
+              {/* 로딩 */}
+              {isFetching && (
+                <p className="text-center text-gray-400 py-4">불러오는 중...</p>
+              )}
+
+              {/* 끝 */}
+              {!hasNext && (
+                <p className="text-center text-gray-400 py-4">더 이상 알림 없음</p>
+              )}
             </div>
           </main>
         )}
@@ -200,7 +239,7 @@ const MyNotificationPage = () => {
         ]}
       />
 
-      {/* 에러 모달 (400 / 404) */}
+      {/* 에러 모달 */}
       <Modal
         isOpen={errorModal.open}
         title={errorModal.message || "알림 오류"}

--- a/src/pages/Main/Info/My/MyStoryPage.tsx
+++ b/src/pages/Main/Info/My/MyStoryPage.tsx
@@ -2,11 +2,12 @@ import { useRef, useCallback, useState } from "react";
 import MyPageHeader from "../../../../components/MyPageHeader";
 import { Pencil, Trash2, Save } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { useMyBookStories } from "../../../../hooks/My/useMyBookStories";
+import { useBookStoriesInfinite } from "../../../../hooks/BookStory/useBookStoriesInfinite"; 
 import type { BookStoryResponseDto, BookStoriesResult } from "../../../../types/bookStories";
 import { deleteBookStory, updateBookStory } from "../../../../apis/BookStory/bookstories";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { InfiniteData } from "@tanstack/react-query";
+import Modal from "../../../../components/Modal"; 
 
 const MyStoryPage = () => {
   const navigate = useNavigate();
@@ -18,10 +19,11 @@ const MyStoryPage = () => {
     hasNextPage,
     isFetchingNextPage,
     isError,
-  } = useMyBookStories();
+  } = useBookStoriesInfinite({ scope: "MY" });
 
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editContent, setEditContent] = useState("");
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null); 
 
   const observerRef = useRef<IntersectionObserver | null>(null);
 
@@ -121,11 +123,9 @@ const MyStoryPage = () => {
           index === self.findIndex((s) => s.bookStoryId === story.bookStoryId)
       ) ?? [];
 
-  // 삭제 버튼 클릭
-  const handleDelete = (id: number) => {
-    if (window.confirm("정말 삭제하시겠습니까?")) {
-      deleteMutation.mutate(id);
-    }
+  // 삭제 버튼 클릭 → 모달 열기
+  const handleDeleteClick = (id: number) => {
+    setDeleteTargetId(id);
   };
 
   // 수정 모드 진입 (제목은 수정 불가)
@@ -144,11 +144,11 @@ const MyStoryPage = () => {
     <div className="flex w-full h-screen bg-[#FAFAFA] overflow-hidden">
       {isError ? (
         // 로그인 안 됐을 때 → 헤더 제거 + 오류 메시지
-          <div className="p-6">
-            <p className="text-red-500">
-              내 책이야기 정보를 불러오는데 실패했습니다. (로그인이 필요합니다)
-            </p>
-          </div>
+        <div className="p-6">
+          <p className="text-red-500">
+            내 책이야기 정보를 불러오는데 실패했습니다. (로그인이 필요합니다)
+          </p>
+        </div>
       ) : (
         // 로그인 성공 시 → 헤더 + 본문
         <>
@@ -225,7 +225,7 @@ const MyStoryPage = () => {
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              handleDelete(story.bookStoryId);
+                              handleDeleteClick(story.bookStoryId); 
                             }}
                             className="text-[#A6917D] hover:text-[#90D26D]"
                           >
@@ -281,6 +281,30 @@ const MyStoryPage = () => {
           </div>
         </>
       )}
+
+      {/* 삭제 확인 모달 */}
+      <Modal
+        isOpen={deleteTargetId !== null}
+        title={"정말 삭제하시겠습니까?"}
+        onBackdrop={() => setDeleteTargetId(null)}
+        buttons={[
+          {
+            label: "아니요",
+            onClick: () => setDeleteTargetId(null),
+            variant: "outline",
+          },
+          {
+            label: "네",
+            onClick: () => {
+              if (deleteTargetId !== null) {
+                deleteMutation.mutate(deleteTargetId);
+                setDeleteTargetId(null);
+              }
+            },
+            variant: "danger",
+          },
+        ]}
+      />
     </div>
   );
 };

--- a/src/pages/Main/Info/My/MySubscriptionPage.tsx
+++ b/src/pages/Main/Info/My/MySubscriptionPage.tsx
@@ -1,13 +1,16 @@
-import { useState } from "react";
+import { useState, useRef, useCallback } from "react";
 import MyPageHeader from "../../../../components/MyPageHeader";
 import { useNavigate } from "react-router-dom";
 import {
-  useMyFollowingQuery,
-  useMyFollowerQuery,
   useUnfollowMember,
   useRemoveFollower,
 } from "../../../../hooks/My/useMember";
+import {
+  useMyFollowerInfinite,
+  useMyFollowingInfinite,
+} from "../../../../hooks/My/useMemberInfinite";
 import Modal from "../../../../components/Modal";
+import type { FollowItem, FollowResponse } from "../../../../types/My/member";
 
 const MySubscriptionPage = () => {
   const navigate = useNavigate();
@@ -19,19 +22,23 @@ const MySubscriptionPage = () => {
     message: "",
   });
 
-  // 구독 중(팔로잉) 목록
+  // 무한스크롤 팔로워
   const {
-    data: followingData,
-    isFetching: followingLoading,
-    isError: followingError,
-  } = useMyFollowingQuery(null);
-
-  // 구독자(팔로워) 목록
-  const {
-    data: followerData,
-    isFetching: followerLoading,
+    data: followerPages,
+    fetchNextPage: fetchNextFollower,
+    hasNextPage: hasNextFollower,
+    isFetchingNextPage: followerLoading,
     isError: followerError,
-  } = useMyFollowerQuery(null);
+  } = useMyFollowerInfinite();
+
+  // 무한스크롤 팔로잉
+  const {
+    data: followingPages,
+    fetchNextPage: fetchNextFollowing,
+    hasNextPage: hasNextFollowing,
+    isFetchingNextPage: followingLoading,
+    isError: followingError,
+  } = useMyFollowingInfinite();
 
   // 언팔로우 & 팔로워 삭제 훅
   const unfollowMutation = useUnfollowMember();
@@ -67,72 +74,77 @@ const MySubscriptionPage = () => {
     });
   };
 
+  // IntersectionObserver
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const lastElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observerRef.current) observerRef.current.disconnect();
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting) {
+          if (activeTab === "followers" && hasNextFollower) fetchNextFollower();
+          if (activeTab === "following" && hasNextFollowing) fetchNextFollowing();
+        }
+      });
+      if (node) observerRef.current.observe(node);
+    },
+    [activeTab, hasNextFollower, hasNextFollowing, fetchNextFollower, fetchNextFollowing]
+  );
+
+  // 리스트 합치기
+    const followerList: FollowItem[] =
+    followerPages?.pages.flatMap((p: FollowResponse) => p.followList) ?? [];
+
+    const followingList: FollowItem[] =
+    followingPages?.pages.flatMap((p: FollowResponse) => p.followList) ?? [];
+
+
   /** 구독 중(팔로잉) 리스트 렌더 */
   const renderFollowingList = () => {
     if (followingError) {
-      return (
-        <p className="text-center text-red-500">
-          구독 목록을 불러오는데 실패했습니다. (로그인이 필요합니다)
-        </p>
-      );
+      return <p className="text-center text-red-500">구독 목록을 불러오는데 실패했습니다. (로그인이 필요합니다)</p>;
     }
-    if (!followingData) return null;
 
     return (
       <section className="bg-white border border-[#EAE5E2] rounded-[16px] flex flex-col">
-        <div className="flex-1 overflow-y-auto divide-y divide-[#EAE5E2] hide-scrollbar">
-          <style>
-            {`
-              .hide-scrollbar::-webkit-scrollbar { display: none; }
-              .hide-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
-            `}
-          </style>
-
-          {followingData.followList.map((user) => (
-            <div
-              key={user.nickname}
-              className="flex justify-between items-center px-8 py-5 cursor-pointer hover:bg-[#FAFAFA]"
-              onClick={() => handleProfileClick(user.nickname)}
-            >
-              <div className="flex items-center gap-3">
-                {user.profileImageUrl ? (
-                  <img
-                    src={user.profileImageUrl}
-                    alt={`${user.nickname} 프로필`}
-                    className="rounded-full w-9 h-9 object-cover"
-                  />
-                ) : (
-                  <img
-                    src="/assets/basic_profile.png"
-                    alt="기본 프로필"
-                    className="rounded-full w-9 h-9 object-cover"
-                  />
-                )}
-                <p className="text-[#2C2C2C] text-[18px] font-medium">{user.nickname}</p>
-              </div>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (user.following) {
-                    handleUnfollow(user.nickname);
-                  }
+        {followingList.map((user, idx) => (
+          <div
+            key={user.nickname}
+            ref={idx === followingList.length - 1 ? lastElementRef : null}
+            className="flex justify-between items-center px-8 py-5 cursor-pointer hover:bg-[#FAFAFA]"
+            onClick={() => handleProfileClick(user.nickname)}
+          >
+            <div className="flex items-center gap-3">
+              <img
+                src={user.profileImageUrl || "/assets/basic_profile.png"}
+                alt={`${user.nickname} 프로필`}
+                className="rounded-full w-9 h-9 object-cover"
+                onError={(e) => {
+                  e.currentTarget.src = "/assets/basic_profile.png";
                 }}
-                className={`px-3 py-1 rounded-full text-[13px] font-medium text-white ${
-                  user.following
-                    ? "bg-[#90D26D] hover:bg-[#7bb95b]"
-                    : "bg-[#8D8D8D] hover:bg-[#aaa]"
-                }`}
-              >
-                {user.following ? "삭제" : "구독"}
-              </button>
+              />
+              <p className="text-[#2C2C2C] text-[18px] font-medium">{user.nickname}</p>
             </div>
-          ))}
-
-          {followingLoading && <p className="text-center text-gray-400 py-4">불러오는 중...</p>}
-          {!followingData.hasNext && !followingLoading && (
-            <p className="text-center text-gray-400 py-4">더 이상 사용자 없음</p>
-          )}
-        </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                if (user.following) {
+                  handleUnfollow(user.nickname);
+                }
+              }}
+              className={`px-3 py-1 rounded-full text-[13px] font-medium text-white ${
+                user.following
+                  ? "bg-[#90D26D] hover:bg-[#7bb95b]"
+                  : "bg-[#8D8D8D] hover:bg-[#aaa]"
+              }`}
+            >
+              {user.following ? "삭제" : "구독"}
+            </button>
+          </div>
+        ))}
+        {followingLoading && <p className="text-center text-gray-400 py-4">불러오는 중...</p>}
+        {!hasNextFollowing && followingList.length > 0 && (
+          <p className="text-center text-gray-400 py-4">더 이상 사용자 없음</p>
+        )}
       </section>
     );
   };
@@ -140,78 +152,46 @@ const MySubscriptionPage = () => {
   /** 구독자(팔로워) 리스트 렌더 */
   const renderFollowerList = () => {
     if (followerError) {
-      return (
-        <p className="text-center text-red-500">
-          구독자 목록을 불러오는데 실패했습니다.
-        </p>
-      );
+      return <p className="text-center text-red-500">구독자 목록을 불러오는데 실패했습니다.</p>;
     }
-    if (!followerData) return null;
 
     return (
       <section className="bg-white border border-[#EAE5E2] rounded-[16px] flex flex-col">
-        <div className="flex-1 overflow-y-auto divide-y divide-[#EAE5E2] hide-scrollbar">
-          <style>
-            {`
-              .hide-scrollbar::-webkit-scrollbar { display: none; }
-              .hide-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
-            `}
-          </style>
-
-          {followerData.followList.map((user) => (
-            <div
-              key={user.nickname}
-              className="flex justify-between items-center px-8 py-5 cursor-pointer hover:bg-[#FAFAFA]"
-              onClick={() => handleProfileClick(user.nickname)}
-            >
-              <div className="flex items-center gap-3">
-                {user.profileImageUrl ? (
-                  <img
-                    src={user.profileImageUrl}
-                    alt={`${user.nickname} 프로필`}
-                    className="rounded-full w-9 h-9 object-cover"
-                  />
-                ) : (
-                  <img
-                    src="/assets/basic_profile.png"
-                    alt="기본 프로필"
-                    className="rounded-full w-9 h-9 object-cover"
-                  />
-                )}
-                <p className="text-[#2C2C2C] text-[18px] font-medium">{user.nickname}</p>
-              </div>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleRemoveFollower(user.nickname);
+        {followerList.map((user, idx) => (
+          <div
+            key={user.nickname}
+            ref={idx === followerList.length - 1 ? lastElementRef : null}
+            className="flex justify-between items-center px-8 py-5 cursor-pointer hover:bg-[#FAFAFA]"
+            onClick={() => handleProfileClick(user.nickname)}
+          >
+            <div className="flex items-center gap-3">
+              <img
+                src={user.profileImageUrl || "/assets/basic_profile.png"}
+                alt={`${user.nickname} 프로필`}
+                className="rounded-full w-9 h-9 object-cover"
+                onError={(e) => {
+                  e.currentTarget.src = "/assets/basic_profile.png";
                 }}
-                className="px-3 py-1 rounded-full text-[13px] font-medium text-white bg-[#90D26D] hover:bg-[#7bb95b]"
-              >
-                삭제
-              </button>
+              />
+              <p className="text-[#2C2C2C] text-[18px] font-medium">{user.nickname}</p>
             </div>
-          ))}
-
-          {followerLoading && <p className="text-center text-gray-400 py-4">불러오는 중...</p>}
-          {!followerData.hasNext && !followerLoading && (
-            <p className="text-center text-gray-400 py-4">더 이상 사용자 없음</p>
-          )}
-        </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRemoveFollower(user.nickname);
+              }}
+              className="px-3 py-1 rounded-full text-[13px] font-medium text-white bg-[#90D26D] hover:bg-[#7bb95b]">
+              삭제
+            </button>
+          </div>
+        ))}
+        {followerLoading && <p className="text-center text-gray-400 py-4">불러오는 중...</p>}
+        {!hasNextFollower && followerList.length > 0 && (
+          <p className="text-center text-gray-400 py-4">더 이상 사용자 없음</p>
+        )}
       </section>
     );
   };
-
-  if (followingError && followerError) {
-    return (
-      <div className="flex w-full h-screen bg-[#FAFAFA] overflow-hidden">
-        <div className="p-6">
-          <p className="text-red-500">
-            내 구독 정보를 불러오는데 실패했습니다. (로그인이 필요합니다)
-          </p>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex w-full h-screen bg-[#FAFAFA] overflow-hidden">
@@ -261,7 +241,7 @@ const MySubscriptionPage = () => {
           },
         ]}
         onBackdrop={() => setErrorModal({ open: false, message: "" })}
-      />    
+      />
     </div>
   );
 };

--- a/src/pages/Main/Info/My/MySubscriptionPage.tsx
+++ b/src/pages/Main/Info/My/MySubscriptionPage.tsx
@@ -91,12 +91,11 @@ const MySubscriptionPage = () => {
   );
 
   // 리스트 합치기
-    const followerList: FollowItem[] =
+  const followerList: FollowItem[] =
     followerPages?.pages.flatMap((p: FollowResponse) => p.followList) ?? [];
 
-    const followingList: FollowItem[] =
+  const followingList: FollowItem[] =
     followingPages?.pages.flatMap((p: FollowResponse) => p.followList) ?? [];
-
 
   /** 구독 중(팔로잉) 리스트 렌더 */
   const renderFollowingList = () => {
@@ -106,6 +105,9 @@ const MySubscriptionPage = () => {
 
     return (
       <section className="bg-white border border-[#EAE5E2] rounded-[16px] flex flex-col">
+        {followingList.length === 0 && !followingLoading && (
+          <p className="text-center text-gray-400 py-10">아직 구독한 사용자가 없습니다.</p>
+        )}
         {followingList.map((user, idx) => (
           <div
             key={user.nickname}
@@ -157,6 +159,9 @@ const MySubscriptionPage = () => {
 
     return (
       <section className="bg-white border border-[#EAE5E2] rounded-[16px] flex flex-col">
+        {followerList.length === 0 && !followerLoading && (
+          <p className="text-center text-gray-400 py-10">아직 나를 구독한 사용자가 없습니다.</p>
+        )}
         {followerList.map((user, idx) => (
           <div
             key={user.nickname}

--- a/src/pages/Main/Info/OthersProfilePage.tsx
+++ b/src/pages/Main/Info/OthersProfilePage.tsx
@@ -99,12 +99,18 @@ const OthersProfilePage = () => {
                       src={profile.profileImageUrl}
                       alt={`${profile.nickname} 프로필`}
                       className="w-[40px] h-[40px] rounded-full object-cover"
+                      onError={(e) => {
+                              e.currentTarget.src = "/assets/basic_profile.png";
+                        }}
                     />
                   ) : (
                     <img
                       src="/assets/basic_profile.png"
                       alt="기본 프로필"
                       className="w-[40px] h-[40px] rounded-full bg-white object-cover scale-110"
+                      onError={(e) => {
+                              e.currentTarget.src = "/assets/basic_profile.png";
+                        }}
                     />
                   )}
                   <p className="text-[18px] font-semibold text-[#2C2C2C]">
@@ -174,12 +180,18 @@ const OthersProfilePage = () => {
                             src={book.authorInfo.profileImageUrl}
                             alt={`${book.authorInfo.nickname} 프로필`}
                             className="w-[24px] h-[24px] rounded-full object-cover"
+                            onError={(e) => {
+                              e.currentTarget.src = "/assets/basic_profile.png";
+                            }}
                           />
                         ) : (
                           <img
                             src="/assets/basic_profile.png"
                             alt="기본 프로필"
                             className="w-[24px] h-[24px] rounded-full bg-white object-cover scale-110"
+                            onError={(e) => {
+                              e.currentTarget.src = "/assets/basic_profile.png";
+                            }}
                           />
                         )}
                         <p className="text-[14px] text-[#8D8D8D]">


### PR DESCRIPTION
내 책이야기, 내 알림, 내 구독페이지 무한스크롤 구현

-  내 책 이야기 무한스크롤 구현
-  내 알림 무한스크롤 구현
-  내 구독페이지 무한스크롤 구현
-  이미지 깨짐을 기본이미지로 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 내 알림, 내 스토리, 구독/구독자 목록에 무한 스크롤을 추가하고 자동 로딩/종료 표시를 제공합니다.
  - 구독/구독자 탭 전환을 지원하며 마지막 항목 노출 시 다음 페이지가 자동으로 로드됩니다.
  - 스토리 삭제 시 확인 모달을 도입하고 즉시 반영되는 낙관적 업데이트를 적용했습니다.
- Bug Fixes
  - 프로필/저자 이미지 로딩 실패 시 기본 이미지로 대체해 깨진 이미지를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->