### PR TITLE
[feat] 독서 모임 - 모임 수정 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import MeetingTeamTopicListPage from "./pages/Meeting/MeetingTeamTopicListPage";
 import BookRecommendEditPage from "./pages/BookRecommend/BookRecommendEditPage";
 import MyBookStoryPage from "./pages/Main/BookStory/MyBookStoryPage";
 import MemberBlockPage from "./pages/Admin/MemberBlockPage";
+import MeetingEditPage from "./pages/Meeting/MeetingEditPage";
 const App = () => {
   const qc = useQueryClient();
 
@@ -143,6 +144,7 @@ const App = () => {
             <Route path="meeting">
               <Route index element={<MeetingListPage />} />
               <Route path=":meetingId" element={<MeetingDetailPage />} />
+              <Route path=":meetingId/edit" element={<MeetingEditPage />} />
 
               <Route path="create" element={<MeetingCreatePage />} />
               <Route path=":meetingId/manage" element={<DetailMeatingManagePage />} />

--- a/src/apis/BookSearch/search.ts
+++ b/src/apis/BookSearch/search.ts
@@ -1,10 +1,18 @@
-import { axiosInstance } from '../axiosInstance';
-import type { BookSearchResult } from '../../types/BookSearchdto';
+import { axiosInstance } from "../axiosInstance";
+import type { BookSearchResult, SearchBook } from "../../types/BookSearchdto";
 
 // 책검색 데이터 가져오기
-export function SearchBooks(keyword: string, page: number = 1): Promise<BookSearchResult> {
-  return axiosInstance.get('/books/search', { 
-    params: { keyword, page } 
-  }
-  );
+export function SearchBooks(
+  keyword: string,
+  page: number = 1
+): Promise<BookSearchResult> {
+  return axiosInstance.get("/books/search", {
+    params: { keyword, page },
+  });
 }
+
+// 책 검색 상세 조회
+export const getBookDetail = async (isbn: string): Promise<SearchBook> => {
+  const response: SearchBook = await axiosInstance.get(`/books/${isbn}`);
+  return response;
+};

--- a/src/components/Meeting/MeetingCard.tsx
+++ b/src/components/Meeting/MeetingCard.tsx
@@ -11,6 +11,8 @@ interface MeetingCardProps {
   generation?: number;
   className?: string;
   tagAlign?: "left" | "right";
+  canEdit?: boolean;
+  onEdit?: () => void;
 }
 
 export const MeetingCard = ({
@@ -22,6 +24,8 @@ export const MeetingCard = ({
   generation,
   className = "",
   tagAlign = "right",
+  canEdit = false,
+  onEdit,
 }: MeetingCardProps) => {
   const date = parseISO(meetingDate);
   const dateStr = format(date, "yyyy.MM.dd");
@@ -33,8 +37,8 @@ export const MeetingCard = ({
     <div
       className={
         className
-          ? `${className}`
-          : `flex w-full border-2 border-[#EAE5E2] rounded-xl p-4 bg-white transition-transform duration-300 hover:shadow-lg hover:scale-[1.03] min-w-[700px]`
+          ? `${className} relative`
+          : `relative flex w-full border-2 border-[#EAE5E2] rounded-xl p-4 bg-white transition-transform duration-300 hover:shadow-lg hover:scale-[1.03] min-w-[700px]`
       }
     >
       <div className="w-32 h-40 flex-shrink-0 rounded-2xl overflow-hidden bg-gray-100">
@@ -59,8 +63,10 @@ export const MeetingCard = ({
             </div>
           )}
 
-          <div className={`flex flex-wrap gap-2 max-w-[30%] ${tagAlign === "left" ? "justify-start" : "justify-end"
-            }`}>
+          <div
+            className={`flex flex-wrap gap-2 max-w-[30%] ${tagAlign === "left" ? "justify-start" : "justify-end"
+              }`}
+          >
             {tag &&
               tag.map((t) => (
                 <span
@@ -85,12 +91,16 @@ export const MeetingCard = ({
         <div className="text-sm font-medium space-y-1 mb-1 w-full">
           <p className="text-gray-900 flex items-baseline min-w-0">
             <span className="shrink-0">도서:&nbsp;</span>
-            <span className="truncate block max-w-full" title={book.title}>{book.title}</span>
+            <span className="truncate block max-w-full" title={book.title}>
+              {book.title}
+            </span>
           </p>
 
           <p className="text-gray-900 flex items-baseline min-w-0">
             <span className="shrink-0">작가:&nbsp;</span>
-            <span className="truncate block max-w-full" title={book.author}>{book.author}</span>
+            <span className="truncate block max-w-full" title={book.author}>
+              {book.author}
+            </span>
           </p>
 
           <p className="text-gray-500 break-words md:line-clamp-1" title={dateStr}>
@@ -103,10 +113,27 @@ export const MeetingCard = ({
 
           <p className="text-gray-500 flex items-baseline min-w-0">
             <span className="shrink-0">장소:&nbsp;</span>
-            <span className="truncate block max-w-full" title={meetingPlace}>{meetingPlace}</span>
+            <span className="truncate block max-w-full" title={meetingPlace}>
+              {meetingPlace}
+            </span>
           </p>
         </div>
       </div>
+
+      {canEdit && (
+        <button
+          type="button"
+          aria-label="수정하기"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onEdit?.();
+          }}
+          className="absolute right-4 bottom-2 -translate-y-1/2 px-6 py-2 bg-white text-black text-xs border-2 border-[#A6917D] rounded-2xl hover:bg-gray-200 transition"
+        >
+          수정하기
+        </button>
+      )}
     </div>
   );
 };

--- a/src/hooks/BookSearch/useBookSearch.ts
+++ b/src/hooks/BookSearch/useBookSearch.ts
@@ -1,13 +1,23 @@
-import { useQuery } from '@tanstack/react-query';
-import { SearchBooks } from '../../apis/BookSearch/search';
-import type { BookSearchResult } from '../../types/BookSearchdto';
+import { useQuery } from "@tanstack/react-query";
+import { getBookDetail, SearchBooks } from "../../apis/BookSearch/search";
+import type { BookSearchResult } from "../../types/BookSearchdto";
 
-export function useBookSearch(keyword: string, page: number ) {
-
+export function useBookSearch(keyword: string, page: number) {
   return useQuery<BookSearchResult, Error>({
-    queryKey: ['bookSearch', keyword, page],
-    queryFn: () => {return SearchBooks(keyword, page);},
-    enabled: keyword.trim().length > 0,   // 빈 문자열일 땐 호출 금지
-    staleTime: 1000 * 60 * 5,           // 5분 동안 캐시 유지
+    queryKey: ["bookSearch", keyword, page],
+    queryFn: () => {
+      return SearchBooks(keyword, page);
+    },
+    enabled: keyword.trim().length > 0, // 빈 문자열일 땐 호출 금지
+    staleTime: 1000 * 60 * 5, // 5분 동안 캐시 유지
   });
 }
+
+export const useGetBookDetail = (isbn: string) => {
+  return useQuery({
+    queryKey: ["bookDetail", isbn],
+    queryFn: () => getBookDetail(isbn),
+    enabled: !!isbn,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+};

--- a/src/pages/Meeting/MeetingCreatePage.tsx
+++ b/src/pages/Meeting/MeetingCreatePage.tsx
@@ -4,17 +4,8 @@ import BookSearch from "../../components/Search/BookSearch";
 import Modal from "../../components/Modal";
 import type { SearchBook, Action } from "../../types/BookSearchdto";
 import { useCreateClubMeeting } from "../../hooks/useClubMeeting";
-import type { CreateClubMeeting } from "../../types/clubMeeting";
+import type { CreateClubMeeting, MeetingFormState } from "../../types/clubMeeting";
 import { NonProfileHeader } from "../../components/NonProfileHeader";
-
-type MeetingFormState = {
-  tag: string;
-  generation: string;
-  meetingTime: string;
-  location: string;
-  title: string;
-  content: string;
-};
 
 const MeetingCreatePage = () => {
   const navigate = useNavigate();

--- a/src/pages/Meeting/MeetingEditPage.tsx
+++ b/src/pages/Meeting/MeetingEditPage.tsx
@@ -1,0 +1,288 @@
+import {
+    useState,
+    useCallback,
+    useEffect,
+    useMemo,
+    type KeyboardEvent,
+    type ChangeEvent,
+} from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import Modal from "../../components/Modal";
+import {
+    useUpdateClubMeeting,
+    useMeetingDetail,
+} from "../../hooks/useClubMeeting";
+import type { MeetingFormState, UpdateClubMeeting } from "../../types/clubMeeting";
+import { NonProfileHeader } from "../../components/NonProfileHeader";
+import { formatDateForInput } from "../../utils/formatDate";
+import { useGetBookDetail } from "../../hooks/BookSearch/useBookSearch";
+
+const MeetingEditPage = () => {
+    const navigate = useNavigate();
+    const { bookclubId, meetingId } = useParams<{
+        bookclubId: string;
+        meetingId: string;
+    }>();
+    const clubId = Number(bookclubId ?? 0);
+    const meetId = Number(meetingId ?? 0);
+    const [successModalOpen, setSuccessModalOpen] = useState(false);
+    const [formState, setFormState] = useState<MeetingFormState>({
+        tag: "",
+        generation: "",
+        meetingTime: "",
+        location: "",
+        title: "",
+        content: "",
+    });
+
+    const { data: meetingDetailResult, isLoading: isDetailLoading } =
+        useMeetingDetail(meetId);
+
+    const isbnFromMeeting = useMemo(() => {
+        const id = meetingDetailResult?.meetingInfo?.bookInfo?.bookId;
+        return id != null ? String(id) : "";
+    }, [meetingDetailResult]);
+
+    const { data: bookDetail, isLoading: isBookLoading } = useGetBookDetail(isbnFromMeeting);
+    useEffect(() => {
+        if (!meetingDetailResult) return;
+        const {
+            tag,
+            generation,
+            meetingTime,
+            location,
+            title,
+            content,
+        } = meetingDetailResult.meetingInfo;
+
+        setFormState({
+            tag,
+            generation: `${generation}기`,
+            meetingTime: formatDateForInput(meetingTime),
+            location,
+            title,
+            content,
+        });
+    }, [meetingDetailResult]);
+
+    const [modal, setModal] = useState({ isOpen: false, message: "" });
+    const showAlert = (message: string) => setModal({ isOpen: true, message });
+    const closeModal = () => setModal({ isOpen: false, message: "" });
+
+    const { mutate: updateMeeting, isPending } = useUpdateClubMeeting(meetId);
+
+    const handleFormChange = (
+        e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    ) => {
+        const { name, value } = e.target;
+        const processedValue = name === "tag" ? value.slice(0, 6) : value;
+        setFormState((prev) => ({ ...prev, [name]: processedValue }));
+    };
+
+    const handleTextareaKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Tab") {
+            e.preventDefault();
+            const target = e.currentTarget;
+            const start = target.selectionStart;
+            const end = target.selectionEnd;
+            const newValue =
+                formState.content.substring(0, start) +
+                "\t" +
+                formState.content.substring(end);
+            setFormState((prev) => ({ ...prev, content: newValue }));
+            requestAnimationFrame(() => {
+                target.selectionStart = target.selectionEnd = start + 1;
+            });
+        }
+    };
+
+    const handleSuccessConfirm = () => {
+        setSuccessModalOpen(false);
+        navigate(`/bookclub/${clubId}/meeting/${meetId}`);
+    };
+
+    const handleSubmit = useCallback(() => {
+        if (!clubId || !meetId) return showAlert("유효하지 않은 모임입니다.");
+
+        const { title, tag, generation, meetingTime, location } = formState;
+        if (!title.trim()) return showAlert("제목을 입력해주세요.");
+        if (!tag.trim()) return showAlert("종류(태그)를 입력해주세요.");
+        if (!generation.trim()) return showAlert("기수를 입력해주세요.");
+        if (!meetingTime) return showAlert("날짜/시간을 선택해주세요.");
+        if (!location.trim()) return showAlert("장소를 입력해주세요.");
+
+        const payload: UpdateClubMeeting = {
+            tag: tag.trim(),
+            title: title.trim(),
+            meetingTime: new Date(meetingTime).toISOString(),
+            location: location.trim(),
+            content: formState.content.trim(),
+            generation: Number(generation.replace(/\D/g, "")) || 0,
+        };
+
+        updateMeeting(payload, {
+            onSuccess: () => {
+                setSuccessModalOpen(true);
+            },
+            onError: (err) => {
+                console.error(err);
+                showAlert("모임 수정에 실패했습니다. 다시 시도해주세요.");
+            },
+        });
+    }, [clubId, meetId, formState, updateMeeting]);
+
+    if (isDetailLoading || (isbnFromMeeting && isBookLoading)) {
+        return <div>로딩 중...</div>;
+    }
+
+    return (
+        <div className="mx-10">
+            <Modal
+                isOpen={modal.isOpen}
+                title={modal.message}
+                buttons={[{ label: "확인", onClick: closeModal }]}
+                onBackdrop={closeModal}
+            />
+            <Modal
+                isOpen={successModalOpen}
+                title="수정이 완료되었습니다."
+                buttons={[{ label: "확인", onClick: handleSuccessConfirm }]}
+                onBackdrop={handleSuccessConfirm}
+            />
+
+            <NonProfileHeader title={"모임 수정하기"} />
+
+            {bookDetail && (
+                <div className="flex border-2 border-[var(--sub-color-2-brown,#EAE5E2)] rounded-2xl bg-white shadow-sm min-w-[700px]">
+                    <div className="flex-1 flex p-[10px] gap-[20px]">
+                        <div className="w-[136px] h-[192px] rounded-2xl overflow-hidden bg-gray-200 flex items-center justify-center">
+                            <img
+                                src={bookDetail.imgUrl}
+                                alt={bookDetail.title}
+                                className="w-full h-full object-cover"
+                            />
+                        </div>
+                        <div className="flex-1 flex flex-col">
+                            <div className="flex items-start gap-[5px] mb-4">
+                                <img src="/assets/책 제목.svg" className="w-6 h-6" />
+                                <div className="flex gap-[10px] items-center">
+                                    <h2 className="font-[Pretendard] font-medium text-[18px] leading-[135%]">
+                                        {bookDetail.title}
+                                    </h2>
+                                </div>
+                            </div>
+                            <span className="font-[Pretendard] font-semibold text-[12px] text-[#8D8D8D]">
+                                {bookDetail.author}
+                                {bookDetail.publisher ? ` | 출판 ${bookDetail.publisher}` : ""}
+                            </span>
+                            {bookDetail.description && (
+                                <p className="font-[Pretendard] font-semibold text-[12px] mt-5">
+                                    {bookDetail.description}
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            <div className="mt-5 min-w-[700px]">
+                <label className="font-pretendard font-medium text-[18px] px-[6.5px]">
+                    기수
+                </label>
+                <div className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl bg-[var(--Color-4,#F4F2F1)] mt-3">
+                    <input
+                        type="text"
+                        name="generation"
+                        placeholder="ex. 7기"
+                        className="text-[18px] mx-[14px] font-pretendard font-medium bg-transparent outline-none flex-1"
+                        value={formState.generation}
+                        onChange={handleFormChange}
+                    />
+                </div>
+            </div>
+
+            <div className="mt-5 min-w-[700px]">
+                <label className="font-pretendard font-medium text-[18px] px-[6.5px]">
+                    종류
+                </label>
+                <div className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl bg-[var(--Color-4,#F4F2F1)] mt-3">
+                    <input
+                        type="text"
+                        name="tag"
+                        placeholder="최대 6글자로 입력해주세요."
+                        className="text-[18px] mx-[14px] font-pretendard font-medium bg-transparent outline-none flex-1"
+                        value={formState.tag}
+                        maxLength={6}
+                        onChange={handleFormChange}
+                    />
+                </div>
+            </div>
+
+            <div className="mt-5 min-w-[700px]">
+                <label className="font-pretendard font-medium text-[18px] px-[6.5px]">
+                    날짜
+                </label>
+                <div className="flex items-center h-[53px] py-[10px] px-[17px] rounded-2xl bg-[var(--Color-4,#F4F2F1)] mt-3">
+                    <img src="/assets/일정.svg" className="w-6 h-6" />
+                    <input
+                        type="datetime-local"
+                        name="meetingTime"
+                        value={formState.meetingTime}
+                        onChange={handleFormChange}
+                        className="text-[18px] mx-[14px] font-pretendard font-medium bg-transparent outline-none flex-1"
+                    />
+                </div>
+            </div>
+
+            <div className="mt-5 min-w-[700px]">
+                <label className="font-pretendard font-medium text-[18px] px-[6.5px]">
+                    장소
+                </label>
+                <div className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl bg-[var(--Color-4,#F4F2F1)] mt-3">
+                    <img src="/assets/bx_map.svg" className="w-6 h-6" />
+                    <input
+                        type="text"
+                        name="location"
+                        placeholder="홍익대학교"
+                        className="text-[18px] mx-[14px] font-pretendard font-medium bg-transparent outline-none flex-1"
+                        value={formState.location}
+                        onChange={handleFormChange}
+                    />
+                </div>
+            </div>
+
+            <div className="w-full flex flex-col items-center p-5 gap-[20px] border-2 border-[var(--sub-color-2-brown,#EAE5E2)] rounded-[16px] bg-white my-9 min-w-[700px]">
+                <input
+                    type="text"
+                    name="title"
+                    value={formState.title}
+                    onChange={handleFormChange}
+                    placeholder="제목을 입력해주세요."
+                    className="w-full h-[48px] border-0 border-b-2 border-gray-300 focus:outline-none focus:border-gray-500 font-pretendard font-medium"
+                />
+
+                <textarea
+                    name="content"
+                    value={formState.content}
+                    onChange={handleFormChange}
+                    onKeyDown={handleTextareaKeyDown}
+                    placeholder="내용을 자유롭게 입력해주세요."
+                    className="mt-5 w-full min-h-[300px] font-pretendard text-base outline-none leading-snug resize-none"
+                />
+
+                <div className="flex items-center justify-end gap-4 w-full">
+                    <button
+                        type="button"
+                        disabled={isPending}
+                        className="w-[105px] h-[35px] text-[12px] rounded-[16px] flex items-center justify-center font-[Pretendard] bg-[var(--button-brown,#A6917E)] text-white disabled:opacity-60 transition-colors duration-200 hover:bg-[#907E66]"
+                        onClick={handleSubmit}
+                    >
+                        {isPending ? "수정 중…" : "수정하기"}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default MeetingEditPage;

--- a/src/pages/Meeting/MeetingEditPage.tsx
+++ b/src/pages/Meeting/MeetingEditPage.tsx
@@ -186,79 +186,93 @@ const MeetingEditPage = () => {
             )}
 
             <div className="mt-5 min-w-[700px]">
-                <label className="font-pretendard font-medium text-[18px] px-[6.5px]">
+                <label className="font-medium text-[18px] px-[6.5px]">
                     기수
                 </label>
-                <div className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl bg-[var(--Color-4,#F4F2F1)] mt-3">
+                <div
+                    className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl 
+             bg-[var(--Color-4,#F4F2F1)] my-3 border-2 border-transparent
+             hover:border-[#BFAB96] focus-within:border-[#A6917E] transition"
+                >
                     <input
                         type="text"
                         name="generation"
                         placeholder="ex. 7기"
-                        className="text-[18px] mx-[14px] font-pretendard font-medium bg-transparent outline-none flex-1"
+                        className="text-[18px] mx-[14px]  font-medium bg-transparent outline-none flex-1"
                         value={formState.generation}
                         onChange={handleFormChange}
                     />
                 </div>
-            </div>
 
-            <div className="mt-5 min-w-[700px]">
-                <label className="font-pretendard font-medium text-[18px] px-[6.5px]">
+
+                <label className="font-medium text-[18px] px-[6.5px]">
                     종류
                 </label>
-                <div className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl bg-[var(--Color-4,#F4F2F1)] mt-3">
+                <div
+                    className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl 
+             bg-[var(--Color-4,#F4F2F1)] my-3 border-2 border-transparent
+             hover:border-[#BFAB96] focus-within:border-[#A6917E] transition"
+                >
                     <input
                         type="text"
                         name="tag"
                         placeholder="최대 6글자로 입력해주세요."
-                        className="text-[18px] mx-[14px] font-pretendard font-medium bg-transparent outline-none flex-1"
+                        className="text-[18px] mx-[14px]  font-medium bg-transparent outline-none flex-1"
                         value={formState.tag}
                         maxLength={6}
                         onChange={handleFormChange}
                     />
                 </div>
-            </div>
 
-            <div className="mt-5 min-w-[700px]">
-                <label className="font-pretendard font-medium text-[18px] px-[6.5px]">
+                <label className="font-medium text-[18px] px-[6.5px]">
                     날짜
                 </label>
-                <div className="flex items-center h-[53px] py-[10px] px-[17px] rounded-2xl bg-[var(--Color-4,#F4F2F1)] mt-3">
+                <div
+                    className="flex items-center h-[53px] py-[10px] px-[17px] rounded-2xl 
+             bg-[var(--Color-4,#F4F2F1)] my-3 border-2 border-transparent
+             hover:border-[#BFAB96] focus-within:border-[#A6917E] transition"
+                >
                     <img src="/assets/일정.svg" className="w-6 h-6" />
                     <input
                         type="datetime-local"
                         name="meetingTime"
                         value={formState.meetingTime}
                         onChange={handleFormChange}
-                        className="text-[18px] mx-[14px] font-pretendard font-medium bg-transparent outline-none flex-1"
+                        className="text-[18px] mx-[14px]  font-medium bg-transparent outline-none flex-1"
                     />
                 </div>
-            </div>
 
-            <div className="mt-5 min-w-[700px]">
-                <label className="font-pretendard font-medium text-[18px] px-[6.5px]">
+                <label className="font-medium text-[18px] px-[6.5px]">
                     장소
                 </label>
-                <div className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl bg-[var(--Color-4,#F4F2F1)] mt-3">
+                <div
+                    className="flex items-center h-[53px] py-[10px] px-[10px] rounded-2xl 
+             bg-[var(--Color-4,#F4F2F1)] my-3 border-2 border-transparent
+             hover:border-[#BFAB96] focus-within:border-[#A6917E] transition"
+                >
                     <img src="/assets/bx_map.svg" className="w-6 h-6" />
                     <input
                         type="text"
                         name="location"
                         placeholder="홍익대학교"
-                        className="text-[18px] mx-[14px] font-pretendard font-medium bg-transparent outline-none flex-1"
+                        className="text-[18px] mx-[14px]  font-medium bg-transparent outline-none flex-1"
                         value={formState.location}
                         onChange={handleFormChange}
                     />
                 </div>
             </div>
 
-            <div className="w-full flex flex-col items-center p-5 gap-[20px] border-2 border-[var(--sub-color-2-brown,#EAE5E2)] rounded-[16px] bg-white my-9 min-w-[700px]">
+            <div
+                className="w-full px-5 pb-5 pt-2 border-[#EAE5E2] border-2 rounded-2xl transition
+                   hover:border-[#BFAB96] focus-within:border-[#A6917E] my-9 md:min-w-[700px]"
+            >
                 <input
                     type="text"
                     name="title"
                     value={formState.title}
                     onChange={handleFormChange}
                     placeholder="제목을 입력해주세요."
-                    className="w-full h-[48px] border-0 border-b-2 border-gray-300 focus:outline-none focus:border-gray-500 font-pretendard font-medium"
+                    className="w-full h-[48px] border-0 border-b-2 border-gray-300 focus:outline-none focus:border-gray-500  font-medium"
                 />
 
                 <textarea
@@ -267,7 +281,7 @@ const MeetingEditPage = () => {
                     onChange={handleFormChange}
                     onKeyDown={handleTextareaKeyDown}
                     placeholder="내용을 자유롭게 입력해주세요."
-                    className="mt-5 w-full min-h-[300px] font-pretendard text-base outline-none leading-snug resize-none"
+                    className="mt-5 w-full min-h-[300px]  text-base outline-none leading-snug resize-none"
                 />
 
                 <div className="flex items-center justify-end gap-4 w-full">

--- a/src/pages/Meeting/MeetingListPage.tsx
+++ b/src/pages/Meeting/MeetingListPage.tsx
@@ -1,5 +1,5 @@
 import { MeetingCard } from "../../components/Meeting/MeetingCard";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import Header from "../../components/Header";
 import { useMeetingList } from "../../hooks/useClubMeeting";
 import { useEffect, useMemo } from "react";
@@ -7,10 +7,12 @@ import { useInView } from "react-intersection-observer";
 import type { ClubMeeting } from "../../types/clubMeeting";
 
 const MeetingListPage = () => {
-  const isAdmin = true; // 추후에 로그인 정보로 변경 예정
+  const navigate = useNavigate();
   const { bookclubId } = useParams<{ bookclubId: string }>();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
     useMeetingList(Number(bookclubId));
+  const membership = data?.pages[0].membership;
+  const isAdmin = membership?.clubMemberStatus === 'STAFF';
   const { ref, inView } = useInView();
 
   useEffect(() => {
@@ -21,7 +23,9 @@ const MeetingListPage = () => {
 
   const generations = useMemo(() => {
     if (!data) return [];
-    const meetings = data.pages.flatMap((page) => page.meetingInfoList);
+    const meetings = data.pages.flatMap(
+      ({ meetingInfoList }) => meetingInfoList,
+    );
     const groupedMeetings = meetings.reduce((acc, meeting) => {
       const generation = meeting.generation;
       if (!acc[generation]) {
@@ -88,6 +92,12 @@ const MeetingListPage = () => {
                     meetingPlace={meeting.location}
                     tags={meeting.tag}
                     generation={group.generation}
+                    canEdit={isAdmin}
+                    onEdit={() =>
+                      navigate(
+                        `/bookclub/${bookclubId}/meeting/${meeting.meetingId}/edit`
+                      )
+                    }
                   />
                 </Link>
               ))}

--- a/src/types/clubMeeting.ts
+++ b/src/types/clubMeeting.ts
@@ -23,6 +23,15 @@ export type MemberShip = {
   updatedAt: Date;
 };
 
+export type MeetingFormState = {
+  tag: string;
+  generation: string;
+  meetingTime: string;
+  location: string;
+  title: string;
+  content: string;
+};
+
 export type MeetingListResult = {
   membership: MemberShip;
   meetingInfoList: ClubMeeting[];

--- a/src/types/clubMeeting.ts
+++ b/src/types/clubMeeting.ts
@@ -17,7 +17,14 @@ export interface ClubMeeting {
   bookInfo: BookDto;
 }
 
+export type MemberShip = {
+  clubMemberId: number;
+  clubMemberStatus: string;
+  updatedAt: Date;
+};
+
 export type MeetingListResult = {
+  membership: MemberShip;
   meetingInfoList: ClubMeeting[];
   hasNext: boolean;
   nextCursor: number | null;

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,6 @@
+export const formatDateForInput = (dateString: string): string => {
+  const date = new Date(dateString);
+  const offset = date.getTimezoneOffset() * 60000;
+  const localDate = new Date(date.getTime() - offset);
+  return localDate.toISOString().slice(0, 16);
+};


### PR DESCRIPTION
**MeetingEditPage**

<img width="1220" height="833" alt="스크린샷 2025-08-20 오전 10 59 56" src="https://github.com/user-attachments/assets/5b83bb47-c1ad-4424-90ef-c96bbf79f722" />

https://github.com/user-attachments/assets/d187884b-ddd5-4e4c-8edb-f920bb8cf168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 모임 편집 페이지 추가 및 라우팅 확장(개별 모임 편집 경로 지원).
  - 모임 카드에 편집 버튼 추가(권한 보유자에게만 표시) 및 편집 화면으로 이동.
  - 도서 상세 조회를 연동하여 편집 화면에 도서 정보 표시.
- 개선
  - 권한 노출 로직을 관리자 플래그 대신 멤버십 기반으로 전환.
  - 날짜/시간 입력을 위한 포맷 유틸 추가로 입력 일관성 향상.
- 리팩터링
  - 모임 생성 폼 상태 타입을 공용 타입으로 분리하여 재사용성 및 일관성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->