### PR TITLE
[style] 책장 & booksearch 반응형 수정

### DIFF
--- a/src/components/Search/BookSearch.tsx
+++ b/src/components/Search/BookSearch.tsx
@@ -89,11 +89,8 @@ export default function BookSearch({
           }}
         >
           {Searchbooks.map((SearchBook) => (
-            <div
-              key={SearchBook.isbn}
-              className=""
-            >
-              <div className = "flex border-2 border-[var(--sub-color-2-brown,#EAE5E2)] rounded-2xl bg-[var(--White,#FFF)] shadow-sm  hover:shadow-lg hover:scale-[1.03]">
+            <div key={SearchBook.isbn}>
+              <div className = "flex h-[215px] border-2 border-[var(--sub-color-2-brown,#EAE5E2)] rounded-2xl bg-[var(--White,#FFF)] shadow-sm  hover:shadow-lg hover:scale-[1.03]">
                   {/* 좌측 */}
                 <div className="flex-1 flex p-[10px] gap-[20px]">
                   {/* 썸네일 */}
@@ -110,17 +107,17 @@ export default function BookSearch({
                     <div className="flex items-start gap-[5px] mb-4">
                       <img src="/assets/책 제목.svg" className="w-6 h-6" />
                       <div className="flex gap-[10px] items-center">
-                        <h2 className="font-[Pretendard] font-medium text-[18px] leading-[135%]">
+                        <h2 className="font-[Pretendard] font-medium text-[18px] leading-[135%] line-clamp-3">
                           {SearchBook.title}
                         </h2>
                       </div>
                     </div>
                     {/* 출판사*/}
-                    <span className="font-[Pretendard] font-semibold text-[12px] text-[#8D8D8D]">
+                    <span className="font-[Pretendard] font-semibold text-[12px] text-[#8D8D8D] line-clamp-3">
                       {SearchBook.author} | 출판 {SearchBook.publisher}
                     </span>
                     {/* 요약 */}
-                    <p className="font-[Pretendard] font-semibold text-[12px] mt-5">
+                    <p className="font-[Pretendard] font-semibold text-[12px] mt-5 overflow-hidden">
                       {SearchBook.description}
                     </p>
                   </div>

--- a/src/pages/BookClub/Shelf/ScoreDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ScoreDetailPage.tsx
@@ -36,7 +36,7 @@ export default function ScoreDetailPage() {
             src="/assets/material-symbols_arrow-back-ios.svg"
             className="w-[30px] h-[30px] h-full flex items-center justify-center"
           />
-          <h1 className="font-[Pretendard] font-bold text-[28px] leading-[135%]">
+          <h1 className="font-[Pretendard] font-bold text-[28px] leading-[135%] line-clamp-1">
             {bookTitle}
           </h1>
         </div>

--- a/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
@@ -38,14 +38,14 @@ export default function ShelfDetailPage() {
         {/* 상단 뒤로가기 영역 */}
         <div onClick={() => navigate(-1)} className="flex items-center h-[38px] gap-[3px] cursor-pointer mb-[30px]">
           {/* 1) 왼쪽 아이콘 영역 (30px) */}
-          <div className="w-[30px] h-full flex items-center justify-center">
-            <img src="/assets/material-symbols_arrow-back-ios.svg" className="w-[30px] h-[30px]"/>
-          </div>
+
+          <img src="/assets/material-symbols_arrow-back-ios.svg" className="w-[30px] h-[30px]"/>
+
 
           {/* 2) 책 이름 */}
-          <span className="font-[Pretendard] font-bold text-[28px] leading-[135%]">
+          <h1 className="font-[Pretendard] font-bold text-[28px] leading-[135%] line-clamp-1">
             {ShelfDetail?.bookDetailInfo.title}
-          </span>
+          </h1>
         </div>
         {/* 메인 */}
          <div className="pt-[10px] overflow-y-auto h-[calc(100vh-117px)] overscroll-none " style={{ msOverflowStyle: 'none', scrollbarWidth: 'none' }}>

--- a/src/pages/BookClub/Shelf/ShelfHomePage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfHomePage.tsx
@@ -105,9 +105,9 @@ export default function   ShelfHomePage() {
            </div>
           </div>
           {/* 책장 리스트 */}
-          <div className="pt-[18px] grid grid-cols-3 content-start overflow-y-auto h-[calc(100vh-171px)] overscroll-none px-10"  style={{  gap: "24px 12px",  msOverflowStyle: 'none', scrollbarWidth: 'none' }}>
+          <div className="pt-[18px] grid grid-cols-1 gap-x-1 gap-y-2 lg:grid-cols-2 lg:gap-x-2 lg:gap-y-4 xl:grid-cols-3 lg:gap-x-3 lg:gap-y-6 content-start overflow-y-auto h-[calc(100vh-171px)] overscroll-none px-10"  style={{ msOverflowStyle: 'none', scrollbarWidth: 'none' }}>
                 {ShelfList.map((Shelf) => (
-              <Link key={Shelf.meetingInfo.meetingId} to={`${location.pathname}/${Shelf.meetingInfo.meetingId}`} className="flex min-w-90 h-[260px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] hover:shadow-lg hover:scale-[1.03] transition-shadow block">
+              <Link key={Shelf.meetingInfo.meetingId} to={`${location.pathname}/${Shelf.meetingInfo.meetingId}`} className="flex h-[260px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] hover:shadow-lg hover:scale-[1.03] transition-shadow block">
                   {/* 왼쪽 */}
                   <div className="w-[156px] flex-shrink-0 h-full rounded-2xl overflow-hidden bg-gray-200">
                     <img

--- a/src/pages/BookClub/Shelf/ShelfHomePage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfHomePage.tsx
@@ -130,7 +130,7 @@ export default function   ShelfHomePage() {
                   </p>
                   {/* 3) term, tag  (10px 아래 여백) */}
                   <div className="flex mt-[10px] gap-2 ">
-                    <p className="flex-shrink-0 h-6 w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-[12px]  text-white">
+                    <p className=" h-6 w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-white">
                       {Shelf.meetingInfo.generation}기
                     </p>
                     <p className="flex-shrink-0 h-6 px-3 min-w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-[12px]  text-white">

--- a/src/pages/BookClub/Shelf/TopicDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/TopicDetailPage.tsx
@@ -120,13 +120,8 @@ export default function ThemeDetailPage() {
 
         {/* 상단 뒤로가기 영역 */}
         <div onClick={() => navigate(-1)} className="flex items-center h-[38px] gap-[3px] cursor-pointer mb-[30px]">
-          {/* 1) 왼쪽 아이콘 영역 (30px) */}
-          <div className="w-[30px] h-full flex items-center justify-center">
-            <img src="/assets/material-symbols_arrow-back-ios.svg" className="w-[30px] h-[30px]"/>
-          </div>
-
-          {/* 2) 책 이름 */}
-          <span className="font-[Pretendard] font-bold text-[28px] leading-[135%]">
+          <img src="/assets/material-symbols_arrow-back-ios.svg" className="w-[30px] h-[30px]"/>
+          <span className="font-[Pretendard] font-bold text-[28px] leading-[135%] line-clamp-1">
             {bookTitle}
           </span>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 서재 홈 그리드를 반응형(1/2/3열)으로 개선하고 간격을 정리해 다양한 화면에서 가독성 향상.
  - 검색 결과 및 서재 아이템의 높이·레이아웃을 다듬어 목록 밀도를 균일화.
  - 제목/저자 텍스트에 줄 수 제한과 넘침 숨김을 적용해 긴 텍스트도 깔끔하게 표시.
  - 상세/토픽/스코어 페이지 헤더에서 제목을 한 줄로 고정하고 뒤로가기 아이콘 정렬을 단순화.

- 리팩터
  - 불필요한 래퍼 요소를 제거해 DOM 구조를 간소화(기능 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->