### PR TITLE
[feat] 전체 발제 보기 / 팀 별 발제 보기 페이지 연동

### DIFF
--- a/src/apis/clubMeeting/meetingAPI.ts
+++ b/src/apis/clubMeeting/meetingAPI.ts
@@ -3,6 +3,9 @@ import type {
   CreateClubMeeting,
   MeetingDetailResult,
   MeetingListResult,
+  TeamMemberResult,
+  TeamTopicResult,
+  TotalTopicResult,
   UpdateClubMeeting,
 } from "../../types/clubMeeting";
 
@@ -53,5 +56,37 @@ export const updateClubMeeting = async (
   data: UpdateClubMeeting
 ) => {
   const response = await axiosInstance.patch(`/meetings/${meetingId}`, data);
+  return response;
+};
+
+// 독서 모임 발제 전체 보기
+export const getMeetingTopics = async (
+  meetingId: number
+): Promise<TotalTopicResult> => {
+  const response: TotalTopicResult = await axiosInstance.get(
+    `/meetings/${meetingId}/team-topics`
+  );
+  return response;
+};
+
+// 독서 모임 팀 별 발제 보기
+export const getMeetingTeamTopic = async (
+  meetingId: number,
+  teamNumber: number
+): Promise<TeamTopicResult> => {
+  const response: TeamTopicResult = await axiosInstance.get(
+    `/meetings/${meetingId}/teams/${teamNumber}/topics`
+  );
+  return response;
+};
+
+// 독서 모임 팀 별 참여자 보기
+export const getMeetingTeamMember = async (
+  meetingId: number,
+  teamNumber: number
+): Promise<TeamMemberResult> => {
+  const response: TeamMemberResult = await axiosInstance.get(
+    `/meetings/${meetingId}/teams/${teamNumber}/members`
+  );
   return response;
 };

--- a/src/components/Meeting/TeamTopicParticipant.tsx
+++ b/src/components/Meeting/TeamTopicParticipant.tsx
@@ -1,8 +1,8 @@
-import type { MemberDto } from "../../types/dto";
+import type { AuthorDto } from "../../types/dto";
 
 interface TeamTopicParticipantProps {
-  teamName: string;
-  participants: MemberDto[];
+  teamName: number;
+  participants: AuthorDto[];
 }
 
 const TeamTopicParticipant = ({
@@ -11,21 +11,21 @@ const TeamTopicParticipant = ({
 }: TeamTopicParticipantProps) => {
   return (
     <>
-      <h2 className="text-base font-semibold mb-3">{`${teamName}조`} 참여자</h2>
-      <div className="max-w-[250px] pt-2 pb-4 px-3 border-2 border-[#D6E5CE] rounded-xl">
+      <h2 className="text-base font-semibold mb-3">{String.fromCharCode(64 + teamName)}조 참여자</h2>
+      <div className="max-w-[400px] pt-2 pb-4 px-3 border-2 border-[#D6E5CE] rounded-xl">
         <ul className={`divide-y-2 divide-gray-200 overflow-auto`}>
           {participants.map((p) => (
             <li
-              key={p.memberId}
+              key={p.nickname}
               className="flex items-center mt-2 p-2 border-b-2 border-gray-200"
             >
               <img
-                src={p.imgUrl ?? "/default-avatar.png"}
-                alt={p.nickName}
+                src={p.profileImageUrl ?? "/default-avatar.png"}
+                alt={p.nickname}
                 className="w-8 h-8 rounded-full bg-gray-200 flex-shrink-0"
               />
               <span className="ml-3 text-md font-medium text-black">
-                {p.nickName}
+                {p.nickname}
               </span>
             </li>
           ))}

--- a/src/components/Meeting/TopicCard.tsx
+++ b/src/components/Meeting/TopicCard.tsx
@@ -9,16 +9,18 @@ interface TopicCardProps {
 const TopicCardComponent = ({ content, authorInfo }: TopicCardProps) => {
   return (
     <div className="flex flex-1 min-w-[500px] items-center justify-between bg-[#F4F2F1] p-1 rounded-2xl border-2 border-[#EAE5E2]">
-      <div className="flex items-center space-x-2 flex-1 overflow-hidden">
+      <div className="flex items-center gap-3 flex-1 overflow-hidden">
         <img
           src={authorInfo.profileImageUrl}
           alt={authorInfo.nickname}
-          className="w-8 h-8 mx-2 rounded-full bg-gray-200 flex-shrink-0"
+          className="w-8 h-8 rounded-full bg-gray-200 shrink-0 ml-2"
         />
-        <span className="text-black text-[12px] font-medium whitespace-nowrap ml-5 mr-20">
+        <span className="text-black text-[12px] font-medium w-[120px] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap">
           {authorInfo.nickname}
         </span>
-        <p className="text-black text-[12px] font-medium truncate">{content}</p>
+        <p className="text-black text-[12px] font-medium truncate min-w-0">
+          {content}
+        </p>
       </div>
     </div>
   );

--- a/src/hooks/useClubMeeting.ts
+++ b/src/hooks/useClubMeeting.ts
@@ -8,12 +8,18 @@ import {
   createClubMeeting,
   getMeetingDetail,
   getMeetingList,
+  getMeetingTeamMember,
+  getMeetingTeamTopic,
+  getMeetingTopics,
   updateClubMeeting,
 } from "../apis/clubMeeting/meetingAPI";
 import type {
   CreateClubMeeting,
   MeetingDetailResult,
   MeetingListResult,
+  TeamMemberResult,
+  TeamTopicResult,
+  TotalTopicResult,
   UpdateClubMeeting,
 } from "../types/clubMeeting";
 
@@ -33,6 +39,7 @@ export const useMeetingDetail = (meetingId: number) => {
   return useQuery<MeetingDetailResult, Error>({
     queryKey: ["meeting", meetingId],
     queryFn: () => getMeetingDetail(meetingId),
+    enabled: !!meetingId,
   });
 };
 
@@ -57,5 +64,38 @@ export const useUpdateClubMeeting = (meetingId: number) => {
       queryClient.invalidateQueries({ queryKey: ["meetings"] });
       queryClient.invalidateQueries({ queryKey: ["meeting", meetingId] });
     },
+  });
+};
+
+// 독서 모임 발제 전체 보기
+export const useGetMeetingTopics = (meetingId: number) => {
+  return useQuery<TotalTopicResult, Error>({
+    queryKey: ["meetingTopics", meetingId],
+    queryFn: () => getMeetingTopics(meetingId),
+    enabled: !!meetingId,
+  });
+};
+
+// 독서 모임 팀 별 발제 보기
+export const useGetMeetingTeamTopic = (
+  meetingId: number,
+  teamNumber: number
+) => {
+  return useQuery<TeamTopicResult, Error>({
+    queryKey: ["meetingTeamTopic", meetingId, teamNumber],
+    queryFn: () => getMeetingTeamTopic(meetingId, teamNumber),
+    enabled: !!meetingId && !!teamNumber,
+  });
+};
+
+// 독서 모임 팀 별 참여자 보기
+export const useGetMeetingTeamMember = (
+  meetingId: number,
+  teamNumber: number
+) => {
+  return useQuery<TeamMemberResult, Error>({
+    queryKey: ["meetingTeamMembers", meetingId, teamNumber],
+    queryFn: () => getMeetingTeamMember(meetingId, teamNumber),
+    enabled: !!meetingId && !!teamNumber,
   });
 };

--- a/src/pages/Meeting/MeetingDetailPage.tsx
+++ b/src/pages/Meeting/MeetingDetailPage.tsx
@@ -8,34 +8,27 @@ import { NonProfileHeader } from "../../components/NonProfileHeader";
 import { useMeetingDetail } from "../../hooks/useClubMeeting";
 
 const MeetingDetailPage = () => {
-
   const navigate = useNavigate();
   const { meetingId } = useParams<{ meetingId: string }>();
   const { data, isLoading, isError } = useMeetingDetail(Number(meetingId));
 
+  const title = data?.meetingInfo.bookInfo?.title ?? "";
+  const meetingTime = data?.meetingInfo?.meetingTime ?? "";
+
   const handleMoreTopics = useCallback(() => {
-    if (!data) return;
     navigate("topics", {
       state: {
-        date: data.meetingInfo.meetingTime,
-        bookTitle: data.meetingInfo.bookInfo.title,
-        topics: data.topics,
+        title: title,
+        meetingTime: meetingTime,
       },
     });
-  }, [navigate, data]);
+  }, [navigate, title, meetingTime]);
 
   const handleViewAllTeamTopics = useCallback(
     (team: TeamTopic) => {
-      if (!data) return;
-      navigate(`teamTopic/${team.teamNumber}`, {
-        state: {
-          date: data.meetingInfo.meetingTime,
-          bookTitle: data.meetingInfo.bookInfo.title,
-          topics: team.topics,
-        },
-      });
+      navigate(`teamTopic/${team.teamNumber}`);
     },
-    [navigate, data]
+    [navigate]
   );
 
   if (isLoading) {

--- a/src/pages/Meeting/MeetingDetailPage.tsx
+++ b/src/pages/Meeting/MeetingDetailPage.tsx
@@ -26,9 +26,14 @@ const MeetingDetailPage = () => {
 
   const handleViewAllTeamTopics = useCallback(
     (team: TeamTopic) => {
-      navigate(`teamTopic/${team.teamNumber}`);
+      navigate(`teamTopic/${team.teamNumber}`, {
+        state: {
+          title: title,
+          meetingTime: meetingTime,
+        },
+      });
     },
-    [navigate]
+    [navigate, title, meetingTime]
   );
 
   if (isLoading) {

--- a/src/pages/Meeting/MeetingListPage.tsx
+++ b/src/pages/Meeting/MeetingListPage.tsx
@@ -52,7 +52,7 @@ const MeetingListPage = () => {
   }
 
   return (
-    <div className="px-10 min-h-screen">
+    <div className="px-10 min-h-screen min-w-[700px]">
       <Header pageTitle={"모임"} customClassName="my-[30px]" />
 
       <div className="pt-3 pb-4">

--- a/src/pages/Meeting/MeetingTeamTopicListPage.tsx
+++ b/src/pages/Meeting/MeetingTeamTopicListPage.tsx
@@ -1,40 +1,51 @@
 import { useLocation, useParams } from "react-router-dom";
-import type { Topic } from "../../types/clubMeeting";
 import { format, parseISO } from "date-fns";
 import { NonProfileHeader } from "../../components/NonProfileHeader";
 import { TeamTopicSection } from "../../components/Meeting/TeamTopicSection";
 import TeamTopicParticipant from "../../components/Meeting/TeamTopicParticipant";
+import { useGetMeetingTeamMember, useGetMeetingTeamTopic } from "../../hooks/useClubMeeting";
 
 const MeetingTeamTopicListPage = () => {
-  const { teamId } = useParams<{ teamId: string }>();
+  const { meetingId, teamId } = useParams<{ meetingId: string, teamId: string }>();
   const location = useLocation();
-  const { date, bookTitle, topics } = location.state as {
-    date: string;
-    bookTitle: string;
-    teamNumber: number;
-    topics: Topic[];
-  };
-  const dateStr = format(parseISO(date), "yyyy.MM.dd");
-  const title = `${dateStr} | ${bookTitle}`;
+  const { title, meetingTime } = (location.state as { title: string; meetingTime: string }) || {};
+  const dateStr = format(parseISO(meetingTime), "yyyy.MM.dd");
+  const headerTitle = `${dateStr} | ${title}`;
 
-  const participants = [
-    { memberId: 1, nickName: "oz", imgUrl: "userImage.png" },
-    { memberId: 2, nickName: "ojh", imgUrl: "userImage.png" },
-    { memberId: 3, nickName: "returntooz", imgUrl: "userImage.png" },
-    { memberId: 4, nickName: "re", imgUrl: "userImage.png" },
-    { memberId: 5, nickName: "turnto", imgUrl: "userImage.png" },
-    { memberId: 6, nickName: "ozi", imgUrl: "userImage.png" },
-  ];
+  const meetId = Number(meetingId ?? 0);
+  const tId = Number(teamId ?? 0);
+  const { data: teamTopicResult, isLoading: isTopicLoading } =
+    useGetMeetingTeamTopic(meetId, tId);
+
+  const { data: teamMemberResult, isLoading: isMemeberLoading } =
+    useGetMeetingTeamMember(meetId, tId);
+
+  if (isMemeberLoading || isTopicLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!teamTopicResult) {
+    return <div>Error: Could not fetch teamTopic data.</div>;
+  }
+
+  if (!teamMemberResult) {
+    return <div>Error: Could not fetch teamMember data.</div>;
+  }
+
+  const topics = teamTopicResult.topics;
+  const participants = teamMemberResult.members;
+
   return (
-    <div className="w-full px-10 space-y-10">
-      <NonProfileHeader title={title} />
-      <div className="flex flex-row space-x-10">
-        <div className="flex-1">
-          <TeamTopicSection teamNumber={parseInt(teamId!)} topics={topics} />
+    <div className="w-full px-10 space-y-5 min-w-[900px]">
+      <NonProfileHeader title={headerTitle} />
+      <div className="flex gap-5 md:gap-8 items-start">
+        <div className="flex-1 min-w-0">
+          <TeamTopicSection teamNumber={Number(teamId)} topics={topics} />
         </div>
-        <div className="flex-0">
+
+        <div className="shrink-0 basis-[240px]">
           <TeamTopicParticipant
-            teamName={teamId!}
+            teamName={Number(teamId)}
             participants={participants}
           />
         </div>

--- a/src/pages/Meeting/MeetingTopicListPage.tsx
+++ b/src/pages/Meeting/MeetingTopicListPage.tsx
@@ -1,23 +1,34 @@
-import { useLocation } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import { TopicPreviewSection } from "../../components/Meeting/TopicPreviewSection";
 import { NonProfileHeader } from "../../components/NonProfileHeader";
-import type { Topic } from "../../types/clubMeeting";
+import { useGetMeetingTopics } from "../../hooks/useClubMeeting";
 import { format, parseISO } from "date-fns";
 
 const MeetingTopicListPage = () => {
+  const { meetingId } = useParams<{ meetingId: string }>();
   const location = useLocation();
-  const { date, bookTitle, topics } = location.state as {
-    date: string;
-    bookTitle: string;
-    topics: Topic[];
-  };
-  const dateStr = format(parseISO(date), "yyyy.MM.dd");
+  const { title, meetingTime } = (location.state as { title: string; meetingTime: string }) || {};
 
-  const title = `${dateStr} | ${bookTitle}`;
+  const meetId = Number(meetingId ?? 0);
+  const date = parseISO(meetingTime);
+  const dateStr = format(date, "yyyy.MM.dd");
+
+  const { data: topicsResult, isLoading: areTopicsLoading } =
+    useGetMeetingTopics(meetId);
+
+  if (areTopicsLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!topicsResult) {
+    return <div>Error: Could not fetch meeting data.</div>;
+  }
+
+  const topics = topicsResult.topics;
+
   return (
-    <div className="mx-auto px-10 space-y-10">
-      <NonProfileHeader title={title} />
-
+    <div className="mx-auto px-10 space-y-5">
+      <NonProfileHeader title={dateStr + " | " + title} />
       <TopicPreviewSection previews={topics} />
     </div>
   );

--- a/src/pages/Meeting/MeetingTopicListPage.tsx
+++ b/src/pages/Meeting/MeetingTopicListPage.tsx
@@ -10,8 +10,8 @@ const MeetingTopicListPage = () => {
   const { title, meetingTime } = (location.state as { title: string; meetingTime: string }) || {};
 
   const meetId = Number(meetingId ?? 0);
-  const date = parseISO(meetingTime);
-  const dateStr = format(date, "yyyy.MM.dd");
+  const dateStr = format(parseISO(meetingTime), "yyyy.MM.dd");
+  const headerTitle = `${dateStr} | ${title}`;
 
   const { data: topicsResult, isLoading: areTopicsLoading } =
     useGetMeetingTopics(meetId);
@@ -28,7 +28,7 @@ const MeetingTopicListPage = () => {
 
   return (
     <div className="mx-auto px-10 space-y-5">
-      <NonProfileHeader title={dateStr + " | " + title} />
+      <NonProfileHeader title={headerTitle} />
       <TopicPreviewSection previews={topics} />
     </div>
   );

--- a/src/types/clubMeeting.ts
+++ b/src/types/clubMeeting.ts
@@ -72,8 +72,26 @@ export type TeamTopic = {
   topics: Topic[];
 };
 
-// 전체 발제 목록과 선택한 팀 정보 전체 조회
-export type TopicResponse = ApiResponse<Topic>;
+export type TotalTopicResult = {
+  topics: Topic[];
+  membership: MemberShip;
+};
 
-// 팀 별 선택된 발제 조회
-export type TeamTopicResponse = ApiResponse<TeamTopic>;
+export type TeamTopicResult = {
+  membership: MemberShip;
+  teamTopic: TeamTopic;
+};
+
+export type TeamMemberResult = {
+  membership: MemberShip;
+  members: AuthorDto[];
+};
+
+// 독서 모임 발제와 선택한 팀 정보 전체 조회
+export type TotalTopicResponse = ApiResponse<TotalTopicResult>;
+
+// 팀 별 발제 조회
+export type TeamTopicResponse = ApiResponse<TeamTopicResult>;
+
+// 팀 별 참여자 조회
+export type TeamMemberResponse = ApiResponse<TeamMemberResult>;

--- a/src/types/clubMeeting.ts
+++ b/src/types/clubMeeting.ts
@@ -79,7 +79,8 @@ export type TotalTopicResult = {
 
 export type TeamTopicResult = {
   membership: MemberShip;
-  teamTopic: TeamTopic;
+  teamNumber: number; // 1=A조, 2=B조 …
+  topics: Topic[];
 };
 
 export type TeamMemberResult = {


### PR DESCRIPTION
**MeetingTopicListPage.tsx**

<img width="1218" height="828" alt="스크린샷 2025-08-20 오후 4 50 27" src="https://github.com/user-attachments/assets/ce57185f-44fe-4748-b206-352e69b01a82" />

**MeetingTeamTopicListPage.tsx**

<img width="1219" height="832" alt="스크린샷 2025-08-20 오후 4 50 13" src="https://github.com/user-attachments/assets/e36d4db0-0542-4859-829b-fa05d1a0c6f1" />

[작업 내용]
- API 호출을 위한 커스텀 훅 구현
- 전체 발제 보기 페이지 연동
- 팀 별 발제 보기 페이지 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 회의 토픽, 팀별 토픽, 팀원 목록을 서버에서 불러오는 기능 추가
  - 팀 주제 목록 페이지에 참여자 패널 및 로딩/에러 표시 추가
- Refactor
  - 라우팅 상태 의존 제거, 경로 파라미터 기반 데이터 조회로 전환
  - 헤더 문구를 제목과 모임 시간으로 일원화
- Style
  - 토픽 카드 닉네임/내용 말줄임 개선 및 간격 조정
  - 목록/팀 주제 페이지 최소 너비 확대와 레이아웃 개선
- Chores
  - line-clamp 플러그인 개발 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->