### PR TITLE
[style] 스타일 수정

### DIFF
--- a/src/components/BookClub/AnnouncementCard.tsx
+++ b/src/components/BookClub/AnnouncementCard.tsx
@@ -44,7 +44,7 @@ function AnnouncementCardItem({
   return (
     <div
       onClick={handleCardClick}
-      className="relative w-[312px] h-[377px] rounded-[16px] border-2 border-[#EAE5E2] py-[26px] px-[21.5px] flex flex-col overflow-hidden cursor-pointer select-none
+      className="relative w-[312px] h-[377px] rounded-[16px] border-2 border-[#EAE5E2] py-[26px] px-[21.5px] mb-[20px] flex flex-col overflow-hidden cursor-pointer select-none
       hover:bg-gray-50 hover:shadow-lg hover:scale-[1.03] transition-all duration-300 origin-center"
     >
       <div className="flex justify-between items-center">
@@ -79,7 +79,7 @@ function AnnouncementCardItem({
 
       <div className="mt-[9px]">
         {item.tag === "모임" && item.meetingInfoDTO && (
-          <div className="font-pretendard font-normal text-[12px] leading-[145%] tracking-[-0.1%] text-[#000000] space-y-[4px]">
+          <div className="font-normal text-[12px] text-[#000000] space-y-[4px]">
             <p>
               다음 모임 날짜:{" "}
               {(() => {

--- a/src/components/BookClub/AnnouncementCard.tsx
+++ b/src/components/BookClub/AnnouncementCard.tsx
@@ -44,27 +44,24 @@ function AnnouncementCardItem({
   return (
     <div
       onClick={handleCardClick}
-      className="relative w-[312px] h-[377px] rounded-[16px] border-2 border-[#EAE5E2] py-[26px] px-[21.5px] mb-[20px] flex flex-col overflow-hidden cursor-pointer select-none
+      className="relative w-[312px] h-[380px] rounded-[16px] border-2 border-[#EAE5E2] py-[26px] px-[21.5px] mb-[20px] flex flex-col overflow-hidden cursor-pointer select-none
       hover:bg-gray-50 hover:shadow-lg hover:scale-[1.03] transition-all duration-300 origin-center"
     >
       <div className="flex justify-between items-center">
         <div className="flex items-center">
-          <img src={vector} alt="icon" className="w-[24px] h-[21px]" />
+          <img src={vector} alt="icon" className="w-[24px] h-[24px]" />
           <h3
             className="
               ml-[13px]
-              font-pretendard
               font-medium
               text-[18px]
-              leading-[135%]
-              tracking-[-0.1%]
             "
           >
             {item.title}
           </h3>
         </div>
         <span
-          className={`inline-flex items-center justify-center w-[52px] h-[22px] opacity-100 rounded-[15px] text-[12px] text-[#FFFFFF] font-pretendard font-semibold leading-[145%] tracking-[-0.1%] whitespace-nowrap ${item.tag === "모임"
+          className={`inline-flex items-center justify-center w-[52px] h-[22px] opacity-100 rounded-[15px] text-[12px] text-[#FFFFFF] font-semibold whitespace-nowrap ${item.tag === "모임"
             ? "bg-[#90D26D]"
             : item.tag === "투표"
               ? "bg-[#FF8045]"
@@ -91,8 +88,10 @@ function AnnouncementCardItem({
                 }
               })()}
             </p>
-            <p>다음 모임 책: {item.meetingInfoDTO.bookInfo?.title}</p>
-            <div className="absolute top-[80px] right-[24px]">
+            <p className="line-clamp-1">
+              다음 모임 책: {item.meetingInfoDTO.bookInfo?.title}
+            </p>
+            <div className="absolute top-[67px] right-[24px]">
               <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-3" />
             </div>
             <div className="absolute bottom-[24.5px]">
@@ -112,11 +111,11 @@ function AnnouncementCardItem({
         )}
 
         {item.tag === "투표" && (
-          <div className="font-pretendard font-normal text-[12px] leading-[145%] tracking-[-0.1%] text-[#000000] space-y-[4px]">
+          <div className="font-normal text-[12px] text-[#000000] space-y-[4px]">
             <p className="mt-[24px] mb-[16px] whitespace-pre-line">
               {item.content}
             </p>
-            <div className="absolute top-[80px] right-[24px]">
+            <div className="absolute top-[67px] right-[24px]">
               <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-3" />
             </div>
             <div className="w-[269px] h-[207px] mt-[46px] border-[2px] border-[#EAE5E2] rounded-[16px]">
@@ -132,11 +131,8 @@ function AnnouncementCardItem({
                       w-[224px] h-[46px]
                       cursor-pointer
                       border-b-2 border-[#EAE5E2]
-                      font-pretendard
                       font-medium
                       text-[14px]
-                      leading-[145%]
-                      tracking-[-0.1%]
                       text-[#434343]
                     "
                     >
@@ -171,11 +167,8 @@ function AnnouncementCardItem({
                   bg-[#FF8045] 
                   text-white 
                   rounded-[15px]
-                  font-pretendard
                   font-semibold
                   text-[12px]
-                  leading-[145%]
-                  tracking-[-0.1%]                 
                   whitespace-nowrap
                   cursor-pointer
                 "
@@ -190,14 +183,9 @@ function AnnouncementCardItem({
         <div className="mt-[9px]">
           {item.tag === "공지" && (
             <div
-              className="   
-            font-normal           
-            text-[12px]           
-            text-[#000000]
-            space-y-[4px]    
-             "
+              className="font-normal text-[12px] text-[#000000] space-y-[4px]"
             >
-              <div className="absolute top-[80px] right-[24px]">
+              <div className="absolute top-[67px] right-[24px]">
                 <img src={arrow} alt="icon" className="w-[24px] h-[24px] -mt-3" />
               </div>
               <p className="mt-[46px] font-normal text-[12px] whitespace-pre-line">

--- a/src/components/BookClub/AnnouncementList.tsx
+++ b/src/components/BookClub/AnnouncementList.tsx
@@ -32,14 +32,13 @@ export default function AnnouncementList({
   };
 
   return (
-    <div className="space-y-[12px] mx-auto">
+    <div className="space-y-[12px] mx-auto w-full max-w-[1700px] px-4 sm:px-5">
       {items.map(item => (
         <div
           key={item.id}
           onClick={() => handleItemClick(item)}
           className="
-            w-[1138px] h-[204px]
-            mx-3
+            w-full md:min-h-[204px] min-h-[180px]
             relative flex items-start
             bg-white border-[2px] border-[#EAE5E2] rounded-[16px]
             cursor-pointer
@@ -51,30 +50,30 @@ export default function AnnouncementList({
             <img
               src={item.meetingInfoDTO.bookInfo.imgUrl}
               alt="notice thumbnail"
-              className="w-[128px] h-[164px] ml-[21.5px] mt-[20px] rounded-lg object-cover"
+              className="hidden sm:block sm:w-[128px] sm:h-[164px] ml-4 sm:ml-[21.5px] mt-4 sm:mt-[20px] rounded-lg object-cover"
             />
           ) : (
-            <div className="w-[128px] h-[164px] ml-[21.5px] mt-[20px] rounded-lg flex items-center justify-center overflow-hidden bg-white">
+            <div className="hidden sm:flex sm:w-[128px] sm:h-[164px] ml-4 sm:ml-[21.5px] mt-4 sm:mt-[20px] rounded-lg items-center justify-center overflow-hidden bg-white">
               <img
                 src={logoImage}
                 alt="logo"
-                className="w-[128px] h-[164px] object-contain"
+                className="w-full h-full object-contain"
               />
             </div>
           )}
 
           {/* 오른쪽: 내용 */}
-          <div className="ml-[29px] mt-[23px] w-[883px] h-[158px]">
+          <div className="ml-4 sm:ml-[29px] mt-4 sm:mt-[23px] flex-1 min-w-0">
             {/* 제목 */}
-            <div className="flex items-center">
+            <div className="flex items-center min-w-0">
               <img src={vector} alt="icon" className="w-[24px] h-[24px]" />
-              <p className="ml-[13px] font-pretendard font-medium text-[18px] leading-[135%] tracking-[-0.1%] text-[#000000]">
+              <p className="ml-[13px] font-medium text-[16px] sm:text-[18px] text-[#000000] line-clamp-2">
                 {item.title}
               </p>
             </div>
 
             {/* 본문 */}
-            <div className="mt-[18px] space-y-[5px] font-pretendard font-medium text-[14px] leading-[145%] tracking-[-0.1%] text-[#8D8D8D]">
+            <div className="mt-[12px] sm:mt-[18px] space-y-[5px] font-medium text-[13px] sm:text-[14px] text-[#8D8D8D]">
               {item.tag === '모임' && item.meetingInfoDTO && (
                 <>
                   <p>
@@ -89,7 +88,7 @@ export default function AnnouncementList({
                       })()
                     }
                   </p>
-                  <p>
+                  <p className="line-clamp-2">
                     다음 모임 책: {item.meetingInfoDTO.bookInfo?.title} | {item.meetingInfoDTO.bookInfo?.author}
                   </p>
                 </>
@@ -97,9 +96,9 @@ export default function AnnouncementList({
 
               {item.tag === '투표' && (
                 <>
-                  <p className="whitespace-pre-line">{item.content}</p>
+                  <p className="whitespace-pre-line line-clamp-2">{item.content}</p>
                   {Array.isArray(item.items) && item.items.length > 0 && (
-                    <div className="mt-[8px] text-[13px] text-[#8D8D8D]">
+                    <div className="mt-[8px] text-[12px] sm:text-[13px] text-[#8D8D8D]">
                       {item.items.slice(0, 3).map((opt: voteItemDto, i: number) => (
                         <span key={`${opt.item}-${i}`} className="mr-2">• {opt.item}</span>
                       ))}
@@ -110,7 +109,7 @@ export default function AnnouncementList({
 
               {item.tag === '공지' && item.content && (
                 <>
-                  <p className="whitespace-pre-line">
+                  <p className="whitespace-pre-line line-clamp-2">
                     {item.content}
                   </p>
                 </>
@@ -122,11 +121,10 @@ export default function AnnouncementList({
           <span
             className={`
               absolute top-[23px] right-[21.5px]
-              inline-flex items-center justify-center
-              w-[52px] h-[22px]
+              hidden sm:inline-flex items-center justify-center
+              w-[44px] h-[20px] sm:w-[52px] sm:h-[22px]
               rounded-[15px]
-              font-pretendard text-[12px] font-[600]
-              leading-[145%] tracking-[-0.1%]
+              text-[11px] sm:text-[12px] font-[600]
               text-white whitespace-nowrap
               ${item.tag === '모임' ? 'bg-[#90D26D]' :
                 item.tag === '투표' ? 'bg-[#FF8045]' :
@@ -150,11 +148,11 @@ export default function AnnouncementList({
                 }
               }}
               className="
-                absolute bottom-[63px] right-[21.5px]
-                w-[105px] h-[35px]
+                hidden sm:block absolute sm:bottom-[63px] bottom-[56px] right-[21.5px]
+                w-[88px] h-[32px] sm:w-[105px] sm:h-[35px]
                 border-2 border-[#EAE5E2]
                 rounded-[16px]
-                font-medium text-[12px]
+                font-medium text-[11px] sm:text-[12px]
                 text-[#8D8D8D]
                 bg-white
                 whitespace-nowrap
@@ -177,12 +175,11 @@ export default function AnnouncementList({
               handleItemClick(item);
             }}
             className="
-              absolute bottom-[23px] right-[21.5px]
-              w-[105px] h-[35px]
+              hidden sm:block absolute bottom-[23px] right-[21.5px]
+              w-[96px] h-[32px] sm:w-[105px] sm:h-[35px]
               bg-[#A6917D]
               rounded-[16px]
-              font-pretendard font-medium text-[12px]
-              leading-[145%] tracking-[-0.1%] 
+              font-medium text-[12px]
               text-white
               whitespace-nowrap
               cursor-pointer

--- a/src/components/BookClub/BookStoryCard.tsx
+++ b/src/components/BookClub/BookStoryCard.tsx
@@ -117,8 +117,7 @@ export default function BookStoryCard({
                 />
                 <span
                   className="
-                    font-pretendard font-medium text-[12px]
-                    leading-[145%] tracking-[-0.1%] text-[#000000]
+                    font-medium text-[12px] text-[#000000]
                   "
                 >
                   {userName}
@@ -128,7 +127,7 @@ export default function BookStoryCard({
                 type="button"
                 className={`
                   w-[60px] h-[24px]
-                  font-pretendard font-medium text-[12px] rounded-[15px]
+                  font-medium text-[12px] rounded-[15px]
                   px-[20px] py-[2px]
                   flex items-center justify-center
                   whitespace-nowrap
@@ -157,8 +156,7 @@ export default function BookStoryCard({
               className="
                   w-[256px] h-[80px]
                   mt-[4px]
-                  font-pretendard font-normal text-[14px]
-                  leading-[145%] tracking-[-0.1%] text-[#000000]
+                  font-normal text-[14px] text-[#000000]
                   overflow-hidden
                 "
               title={summary}
@@ -170,11 +168,12 @@ export default function BookStoryCard({
             >
               {summary}
             </p>
-            <button
-              type="button"
-              className="mt-auto flex items-center justify-end gap-[8px] flex items-center gap-[2px]"
-              onClick={handleLike}
-            >
+            <div className="mt-auto flex items-center justify-end gap-[10px] pr-[2px]">
+              <button
+                type="button"
+                className="flex items-center gap-[2px]"
+                onClick={handleLike}
+              >
                 <img
                   src={liked ? filledHeartIcon : emptyHeartIcon}
                   alt={liked ? "liked" : "not liked"}
@@ -184,17 +183,18 @@ export default function BookStoryCard({
                 />
                 <span
                   className="
-                    font-pretendard font-medium text-[12px] text-[#000000]
+                    font-medium text-[12px] text-[#000000]
                   "
                 >
                   {likeCount}
                 </span>
               </button>
-              <img
-                src={sirenIcon}
-                alt="alert"
-                className="w-[24px] h-[24px] cursor-pointer"
-              />
+                <img
+                  src={sirenIcon}
+                  alt="alert"
+                  className="w-[24px] h-[24px] cursor-pointer"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/BookClub/GeneralNoticeContent.tsx
+++ b/src/components/BookClub/GeneralNoticeContent.tsx
@@ -7,15 +7,15 @@ interface GeneralNoticeContentProps {
 
 export default function GeneralNoticeContent({ data }: GeneralNoticeContentProps): React.ReactElement {
   return (
-    <div className="w-[1080px] h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] ml-1">
+    <div className="w-full max-w-[1150px] h-auto min-h-[300px] p-[16px] lg:p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] ml-1 mr-[12px] md:mr-[18px] pr-[12px] md:pr-[18px]">
       {/* 제목 영역 */}
-        <div className="w-full h-[57px] border-b-[2px] border-[#EEEEEE] mb-[20px]">
-          <h3 className="pt-[10px] pb-[20px] pl-[23.5px] font-pretendard font-semibold text-[20px] leading-[145%] tracking-[-0.1%] text-[#000000] ">
+        <div className="w-full h-auto min-h-[57px] border-b-[2px] border-[#EEEEEE] mb-[20px]">
+          <h3 className="pt-[10px] pb-[20px] pl-[23.5px] font-semibold text-[20px] text-[#000000] ">
             {data.title}
           </h3>
       </div>
       {/* 내용 영역 */}
-      <p className="font-pretendard font-medium text-[14px] leading-[180%] tracking-[-0.1%] text-[#2c2c2c] whitespace-pre-line">
+      <p className="font-medium text-[14px] text-[#2c2c2c] whitespace-pre-line">
         {data.content}
       </p>
     </div>

--- a/src/components/BookClub/MeetingNoticeContent.tsx
+++ b/src/components/BookClub/MeetingNoticeContent.tsx
@@ -26,14 +26,14 @@ export default function MeetingNoticeContent({ data }: MeetingNoticeContentProps
   return (
     <div>
       {/* 상단 영역 */}
-      <div className="w-[552px] flex gap-[32px] mb-[12px]">
+      <div className="w-full lg:w-[552px] flex flex-col lg:flex-row gap-[16px] lg:gap-[32px] mb-[12px]">
         {/* 왼쪽: 책 이미지 */}
         <div className="flex-shrink-0">
           {data.bookInfo?.imgUrl && (
             <img
               src={data.bookInfo.imgUrl}
               alt="book cover"
-              className="w-[200px] h-[292px] object-cover"
+              className="w-[140px] h-[204px] md:w-[180px] md:h-[263px] lg:w-[200px] lg:h-[292px] object-cover rounded-[8px]"
             />
           )}
         </div>
@@ -42,30 +42,30 @@ export default function MeetingNoticeContent({ data }: MeetingNoticeContentProps
         <div className="flex-1 relative">
           {/* 책 제목 */}
           <div className="flex items-center justify-between mb-[6px]">
-            <h2 className="font-pretendard font-semibold text-[20px] leading-[135%] tracking-[-0.1%] text-[#000000]">
+            <h2 className="font-semibold text-[18px] md:text-[20px] text-[#000000]">
               {data.bookInfo?.title}
             </h2>
           </div>
 
           {/* 책 정보 */}
           <div className="mb-[20px]">
-            <p className="font-pretendard font-normal text-[14px] leading-[145%] tracking-[-0.1%] text-[#8D8D8D]">
+            <p className="font-normal text-[14px] text-[#8D8D8D]">
             {data.bookInfo?.author ? `${data.bookInfo.author} 지음` : ''}
             </p>
           </div>
 
           {/* 책 설명 */}
           <div className="flex items-center justify-between">
-            <p className="font-pretendard font-normal text-[14px] leading-[135%] tracking-[-0.1%] text-[#000000]">
+            <p className="font-normal text-[14px] text-[#000000]">
               {data.content}
             </p>
           </div>
 
           {/* 태그 */}
-          <div className="absolute bottom-[0px] flex flex-wrap gap-[8px]">
+          <div className="flex flex-wrap gap-[8px] mt-[12px] lg:mt-0 lg:absolute lg:bottom-[0px]">
             {/* 기수 태그 */}
             {data.generation && (
-              <span className="inline-flex items-center justify-center min-w-[54px] px-[18px] h-[24px] bg-[#90D26D] text-white rounded-[15px] font-pretendard font-medium text-[12px] leading-[145%] tracking-[-0.1%]">
+              <span className="inline-flex items-center justify-center min-w-[54px] px-[18px] h-[24px] bg-[#90D26D] text-white rounded-[15px] font-medium text-[12px]">
                 {data.generation}기
               </span>
             )}
@@ -77,7 +77,7 @@ export default function MeetingNoticeContent({ data }: MeetingNoticeContentProps
               .map((tagLabel, index) => (
                 <span
                   key={`${tagLabel}-${index}`}
-                  className="inline-flex items-center justify-center min-w-[54px] px-[18px] h-[24px] bg-[#90D26D] text-white rounded-[15px] font-pretendard font-medium text-[12px] leading-[145%] tracking-[-0.1%]"
+                  className="inline-flex items-center justify-center min-w-[54px] px-[18px] h-[24px] bg-[#90D26D] text-white rounded-[15px] font-medium text-[12px]"
                 >
                   {tagLabel}
                 </span>
@@ -88,12 +88,12 @@ export default function MeetingNoticeContent({ data }: MeetingNoticeContentProps
 
       {/* 일정 */}
       <div className="flex flex-col mb-[20px]">
-        <h3 className="font-pretendard font-medium text-[18px] leading-[145%] tracking-[-0.1%] text-[#000000]">
+        <h3 className="font-medium text-[18px] text-[#000000]">
           날짜
         </h3>
-        <div className="bg-[#F4F2F1] w-[1080px] h-[53px] mt-[19px] rounded-[16px] flex items-center gap-[12px]">
+        <div className="bg-[#F4F2F1] w-full max-w-[1170px] h-auto min-h-[53px] mt-[12px] lg:mt-[19px] rounded-[16px] flex items-center gap-[12px] py-[12px]">
           <img src={calenderIcon} alt="calendar" className="w-[24px] h-[24px] ml-[20px]" />
-          <p className="font-pretendard font-medium text-[18px] leading-[145%] tracking-[-0.1%] text-[#000000]">
+          <p className="font-medium text-[18px] text-[#000000]">
             {formatMeetingTime(data.meetingTime)}
           </p>
         </div>
@@ -101,20 +101,20 @@ export default function MeetingNoticeContent({ data }: MeetingNoticeContentProps
 
       {/* 장소 */}
       <div className="flex flex-col mb-[36px]">
-        <h3 className="font-pretendard font-medium text-[18px] leading-[145%] tracking-[-0.1%] text-[#000000]">
+        <h3 className="font-medium text-[18px] text-[#000000]">
           장소
         </h3>
-        <div className="bg-[#F4F2F1] w-[1080px] h-[53px] mt-[19px] rounded-[16px] flex items-center gap-[12px]">
+        <div className="bg-[#F4F2F1] w-full max-w-[1170px] h-auto min-h-[53px] mt-[12px] lg:mt-[19px] rounded-[16px] flex items-center gap-[12px] py-[12px]">
           <img src={mapIcon} alt="map" className="w-[24px] h-[24px] ml-[20px]" />
-          <p className="font-pretendard font-medium text-[18px] leading-[145%] tracking-[-0.1%] text-[#000000]">
+          <p className="font-medium text-[18px] text-[#000000]">
             {data.location}
           </p>
         </div>
       </div>
 
       {/* 하단: 상세 설명 */}
-      <div className="w-[1080px] h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px]">
-        <p className="font-pretendard font-medium text-[14px] leading-[180%] tracking-[-0.1%] text-[#2c2c2c] whitespace-pre-line">
+      <div className="w-full max-w-[1170px] h-auto p-[16px] lg:p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px]">
+        <p className="font-medium text-[14px] text-[#2c2c2c] whitespace-pre-line">
           {data.content}
         </p>
       </div>

--- a/src/components/BookClub/MeetingNoticeContent.tsx
+++ b/src/components/BookClub/MeetingNoticeContent.tsx
@@ -113,7 +113,7 @@ export default function MeetingNoticeContent({ data }: MeetingNoticeContentProps
       </div>
 
       {/* 하단: 상세 설명 */}
-      <div className="w-full max-w-[1170px] h-auto p-[16px] lg:p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px]">
+      <div className="w-full max-w-[1170px] h-auto p-[16px] lg:p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] mr-[12px] md:mr-[18px]">
         <p className="font-medium text-[14px] text-[#2c2c2c] whitespace-pre-line">
           {data.content}
         </p>

--- a/src/components/BookClub/VoteNoticeContent.tsx
+++ b/src/components/BookClub/VoteNoticeContent.tsx
@@ -270,7 +270,7 @@ export default function VoteNoticeContent({ data, registerBackBlocker }: VoteNot
   return (
     <div>
       {/* 메인 콘텐츠 영역 */}
-      <div className="w-full max-w-[1150px] min-h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] ml-1">
+      <div className="w-full max-w-[1150px] min-h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] ml-1 mr-[12px] md:mr-[18px]">
         
         {/* 제목 영역 */}
         <div className="w-full h-[57px] border-b-[2px] border-[#EEEEEE] mb-[20px]">

--- a/src/components/BookClub/VoteNoticeContent.tsx
+++ b/src/components/BookClub/VoteNoticeContent.tsx
@@ -270,11 +270,11 @@ export default function VoteNoticeContent({ data, registerBackBlocker }: VoteNot
   return (
     <div>
       {/* 메인 콘텐츠 영역 */}
-      <div className="w-[1080px] min-h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] ml-1">
+      <div className="w-full max-w-[1150px] min-h-[622px] p-[20px] border-[2px] border-[#EAE5E2] rounded-[16px] mb-[36px] ml-1">
         
         {/* 제목 영역 */}
         <div className="w-full h-[57px] border-b-[2px] border-[#EEEEEE] mb-[20px]">
-          <h3 className="pt-[10px] pb-[20px] pl-[23.5px] font-pretendard font-semibold text-[20px] leading-[145%] tracking-[-0.1%] text-[#000000] ">
+          <h3 className="pt-[10px] pb-[20px] pl-[23.5px] font-semibold text-[20px] text-[#000000] ">
             {current.title}
           </h3>
         </div>
@@ -306,12 +306,12 @@ export default function VoteNoticeContent({ data, registerBackBlocker }: VoteNot
         })()}
 
         {/* 투표 설명 */}
-        <p className="px-[20px] py-[10px] font-pretendard font-medium text-[18px] leading-[180%] tracking-[-0.1%] text-[#2c2c2c] whitespace-pre mb-[20px]">
+        <p className="px-[20px] py-[10px] font-medium text-[18px] text-[#2c2c2c] whitespace-pre mb-[20px]">
             {current.content}
         </p>
 
         {/* 투표 섹션 */}
-        <div className="w-[969px] px-[40px] mt-[40px]">
+        <div className="w-full px-[40px] mt-[40px]">
           <form onSubmit={handleVoteSubmit}>
             
             {/* 투표 옵션들 */}
@@ -333,11 +333,11 @@ export default function VoteNoticeContent({ data, registerBackBlocker }: VoteNot
                   />
                   
                   {/* 투표 옵션 박스 */}
-                  <div className={`w-[933px] h-[64px] rounded-[16px] p-[20px] flex items-center justify-between ${
+                  <div className={`w-full h-[64px] rounded-[16px] p-[20px] flex items-center justify-between ${
                     hasVoted ? 'bg-[#FFFFFF] border-[2px] border-[#DED6CD]' : 'bg-[#EEEEEE]'
                   }`}>
                     {/* 옵션 라벨 (왼쪽) */}
-                    <span className="font-pretendard font-medium text-[18px] leading-[145%] tracking-[-0.1%] text-[#2C2C2C]">
+                    <span className="font-medium text-[18px] text-[#2C2C2C]">
                       {option.item}
                     </span>
                     
@@ -362,7 +362,7 @@ export default function VoteNoticeContent({ data, registerBackBlocker }: VoteNot
                 <button
                   type="submit"
                   disabled={selectedIndexes.length === 0}
-                  className="w-[105px] h-[35px] bg-[#FF8045] text-white rounded-[16px] font-pretendard font-semibold text-[12px] leading-[145%] tracking-[-0.1%] whitespace-nowrap cursor-pointer disabled:bg-gray-400 disabled:cursor-not-allowed"
+                  className="w-[105px] h-[35px] bg-[#FF8045] text-white rounded-[16px] font-semibold text-[12px] whitespace-nowrap cursor-pointer disabled:bg-gray-400 disabled:cursor-not-allowed"
                 >
                   투표하기
                 </button>
@@ -371,7 +371,7 @@ export default function VoteNoticeContent({ data, registerBackBlocker }: VoteNot
                 <button
                   type="button"
                   onClick={handleRevote}
-                  className="w-[105px] h-[35px] bg-[#FF8045] text-white rounded-[16px] font-pretendard font-semibold text-[12px] leading-[145%] tracking-[-0.1%] whitespace-nowrap cursor-pointer hover:bg-[#e6723e] transition-colors"
+                  className="w-[105px] h-[35px] bg-[#FF8045] text-white rounded-[16px] font-semibold text-[12px] whitespace-nowrap cursor-pointer hover:bg-[#e6723e] transition-colors"
                 >
                   다시 투표
                 </button>

--- a/src/components/BookClub/VoterDropdown.tsx
+++ b/src/components/BookClub/VoterDropdown.tsx
@@ -24,7 +24,7 @@ export default function VoterDropdown({
         type="button"
         onClick={onToggle}
         aria-label={`${optionLabel} 투표자 목록 토글`}
-        className="cursor-pointer w-[105px] h-[44px] bg-[#EEEEEE] rounded-[16px] font-pretendard font-medium text-[14px] text-[#434343] leading-[145%] tracking-[-0.1%] flex items-center justify-center gap-[6px]"
+        className="cursor-pointer w-[105px] h-[44px] bg-[#EEEEEE] rounded-[16px] font-medium text-[14px] text-[#434343] flex items-center justify-center gap-[6px]"
       >
         <span>{voterCount}명</span>
         <img
@@ -36,7 +36,7 @@ export default function VoterDropdown({
 
       {/* 투표자 목록 드롭다운 */}
       {isOpen && (
-        <div className="absolute left-0 top-[50px] w-[271px] bg-[#FFFFFF] border-[1px] border-[#DED6CD] rounded-[16px] z-10 max-h-[289px] overflow-hidden">
+        <div className="absolute left-0 top-[50px] w-[200px] bg-[#FFFFFF] border-[1px] border-[#DED6CD] rounded-[16px] z-10 max-h-[289px] overflow-hidden">
           {/* 투표자 목록 */}
           <div className="max-h-[289px] overflow-y-auto">
             <div className="p-3 space-y-2">

--- a/src/components/SearchClub/ClubCard.tsx
+++ b/src/components/SearchClub/ClubCard.tsx
@@ -55,7 +55,7 @@ const ActionButtons: React.FC<{
     : 'absolute right-[20px] top-[107px]';
   
   return (
-    <div className={`${positionClass} flex flex-col gap-[10px]`}>
+    <div className={`${positionClass} hidden sm:flex flex-col gap-[10px]`}>
       <ActionButton
         variant="primary"
         onClick={onJoinClick}
@@ -173,7 +173,7 @@ export default function ClubCard({
         <img
           src={logoUrl ?? checker}
           alt="club"
-          className="w-[164px] h-[164px] ml-[20px] mt-[20px] rounded-lg object-cover"
+          className="hidden sm:block w-[164px] h-[164px] ml-[20px] mt-[20px] rounded-lg object-cover"
         />
 
         {/* 정보 영역 */}

--- a/src/pages/BookClub/BookClubHomePage.tsx
+++ b/src/pages/BookClub/BookClubHomePage.tsx
@@ -104,10 +104,10 @@ export default function BookClubHomePage(): React.ReactElement {
         />
       { /* ── 메인 컨텐츠 ── */}
       <div className="overflow-y-auto h-[calc(100vh-80px)] w-full flex-1 pt-[57px] pl-[2px] pr-[30px] bg-[#FFFFFF]">
-        <div className="flex flex-col gap-[36px]">
+        <div className="flex flex-col gap-[20px]">
           {/* ── 공지사항 섹션 ── */}
           <section className="w-full">
-            <div className="flex justify-between items-center mb-4">
+            <div className="px-[7px] flex justify-between items-center mb-4">
               <h2 className="text-[18px] font-semibold">공지사항</h2>  
               <Link to={`/bookclub/${numericClubId}/notices`} className="text-[14px] text-[#969696] mr-1 hover:underline">
                 + 더보기
@@ -142,7 +142,7 @@ export default function BookClubHomePage(): React.ReactElement {
           </section>
 
           {/* ── 책 이야기 섹션 ── */}
-          <section className="w-full h-[376px] mb-[60px]">
+          <section className="px-[7px] w-full h-[376px] mb-[60px]">
             <div className="flex justify-between items-center mb-[20px]">
               <h2 className="text-[18px] font-semibold">책 이야기</h2>
               <Link to={`/bookstory`} className="text-[14px] text-[#8D8D8D] mr-2 hover:underline">

--- a/src/pages/BookClub/NoticeDetailPage.tsx
+++ b/src/pages/BookClub/NoticeDetailPage.tsx
@@ -37,7 +37,7 @@ export default function NoticeDetailPage(): React.ReactElement {
         </h1>
       </div>
 
-      <div className="ml-[5px] sm:ml-[5px] overflow-y-auto h-[calc(100vh-110px)] w-full">
+      <div className="ml-[5px] sm:ml-[5px] pr-[12px] md:pr-[18px] overflow-y-auto h-[calc(100vh-110px)] w-full">
         {!hasValidIds ? (
           <div className="w-full h-[120px] flex items-center justify-center">
             <p className="text-red-500">유효하지 않은 공지입니다.</p>

--- a/src/pages/BookClub/NoticeDetailPage.tsx
+++ b/src/pages/BookClub/NoticeDetailPage.tsx
@@ -32,12 +32,12 @@ export default function NoticeDetailPage(): React.ReactElement {
         >
           <img src={backIcon} alt="back" />
         </button>
-        <h1 className="font-pretendard font-semibold text-[24px] leading-[135%] tracking-[-0.1%] text-[#2c2c2c]">
+        <h1 className="font-bold text-[24px] text-[#2c2c2c]">
           공지사항
         </h1>
       </div>
 
-      <div className=" overflow-y-auto h-[calc(100vh-100px)] w-full">
+      <div className="ml-[5px] sm:ml-[5px] overflow-y-auto h-[calc(100vh-110px)] w-full">
         {!hasValidIds ? (
           <div className="w-full h-[120px] flex items-center justify-center">
             <p className="text-red-500">유효하지 않은 공지입니다.</p>

--- a/src/pages/BookClub/NoticePage.tsx
+++ b/src/pages/BookClub/NoticePage.tsx
@@ -43,12 +43,12 @@ export default function NoticePage(): React.ReactElement {
   return (
     <div className="w-full h-screen flex flex-col">
       <Header pageTitle={'공지사항'}
-        customClassName="mt-[30px] ml-[52px] mr-[41px] mb-[15px]"
+        customClassName="mt-[20px] sm:mt-[30px] ml-4 sm:ml-[52px] mr-4 sm:mr-[41px] mb-[10px] sm:mb-[15px]"
       />
 
-      <div className="flex-1 overflow-y-auto ml-[52px] mr-8">
+      <div className="flex-1 overflow-y-auto sm:ml-[52px] sm:mr-8">
         <div className="mt-[15px]">
-          <section className="mb-6">
+          <section className="sm:ml-4 mb-6">
             {topLoading && (
               <div className="w-full h-[120px] flex items-center justify-center border-2 border-[#EAE5E2] rounded-[16px]">
                 <p className="text-[#969696]">중요 공지사항을 불러오는 중...</p>
@@ -71,7 +71,7 @@ export default function NoticePage(): React.ReactElement {
 
           <section className="mt-[43px]">
             {isStaff && (
-              <div className="relative h-[48px] mb-4 mr-[20px]">
+              <div className="relative h-[48px] mb-4 mr-0 sm:mr-[20px]">
                 <NoticeCreateDropdown
                   onSelectNoticeType={(type) => {
                     const noticeType = type === 'vote' ? 'poll' : 'notice';


### PR DESCRIPTION
# 제목 [style] 스타일 수정

## 작업내용

1. 북클럽 홈화면 스타일 수정
2. 북클럽 공지사항 홈화면 스타일 수정
3. 북클럽 공지 카드 스타일 수정
4. 북클럽 공지 리스트 스타일 수정
5. 북클럽 공지사항 상세페이지 스타일 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 북클럽 공지/투표/모임 상세와 리스트 전반에 반응형 레이아웃을 적용해 모바일·태블릿·데스크톱 가독성을 개선했습니다.
  - 폰트·행간·자간을 단순화하고 라인 클램프를 도입해 제목·본문·옵션 등 긴 텍스트의 넘침을 깔끔히 처리합니다.
  - 카드, 버튼, 태그, 아이콘의 간격·정렬·호버 효과를 다듬고 높이·패딩을 미세 조정했습니다.
  - 모바일에서 불필요한 요소(클럽 카드 액션, 로고, 일부 이미지)를 숨기고 배치를 최적화했습니다.
  - 페이지 헤더/컨텐츠 좌우 패딩과 스크롤 영역을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->