### PR TITLE
[Fix] 메인 홈 - 공지사항 무한요청 수정

### DIFF
--- a/src/pages/Main/HomePage.tsx
+++ b/src/pages/Main/HomePage.tsx
@@ -129,7 +129,7 @@ export default function HomePage() {
         <div className="text-xl font-semibold text-gray-800 mb-4 pl-2">
           공지사항
         </div>
-        {loadingNotices && <p>공지사항 로딩중...</p>}
+        {loadingNotices && <p className=" pl-2">공지사항 로딩중...</p>}
         <div
           className="flex gap-4 overflow-x-auto flex-nowrap scroll-smooth mb-12 p-2
                         max-sm:flex-col max-sm:overflow-x-hidden max-sm:gap-3"
@@ -159,9 +159,11 @@ export default function HomePage() {
         <div className="text-xl font-semibold text-gray-800 mb-4 pl-2">
           책 이야기
         </div>
-        {bookStories.length === 0 && loadingBooks && <p>책 이야기 로딩중...</p>}
+        {bookStories.length === 0 && loadingBooks && (
+          <p className="pl-2">책 이야기 로딩중...</p>
+        )}
         {errorBooks && (
-          <p className="text-red-500">책 이야기 에러: {errorBooks}</p>
+          <p className="text-red-500 pl-2">책 이야기 에러: {errorBooks}</p>
         )}
         <div
           className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 

--- a/src/pages/Main/HomePage.tsx
+++ b/src/pages/Main/HomePage.tsx
@@ -58,26 +58,35 @@ export default function HomePage() {
   }, []);
 
   useEffect(() => {
-    setLoadingNotices(true);
-    fetchMyClubs()
-      .then((clubs) =>
-        Promise.all(
-          clubs.map(async (club) => {
+    const fetchNoticesSequentially = async () => {
+      setLoadingNotices(true);
+      try {
+        const clubs = await fetchMyClubs();
+        const allNotices: NoticeDto[] = [];
+
+        for (const club of clubs) {
+          try {
             const notices = await fetchNoticesByClub(club.clubId);
-            return notices.map((notice) => ({
-              ...notice,
-              clubId: club.clubId,
-            }));
-          })
-        )
-      )
-      .then((noticesArrays) => {
-        const allNotices = noticesArrays.flat();
-        console.log("모든 공지사항:", allNotices); // <- 최종 데이터 확인
+            allNotices.push(
+              ...notices.map((notice) => ({ ...notice, clubId: club.clubId }))
+            );
+            // 서버 과부하 방지용 딜레이 150ms
+            await new Promise((res) => setTimeout(res, 150));
+          } catch (err) {
+            console.error(`클럽 ${club.clubId} 공지 가져오기 실패`, err);
+          }
+        }
+
+        console.log("모든 공지사항:", allNotices);
         setNotices(allNotices);
-      })
-      .catch((err) => console.error("공지사항 불러오기 실패", err))
-      .finally(() => setLoadingNotices(false));
+      } catch (err) {
+        console.error("클럽 가져오기 실패", err);
+      } finally {
+        setLoadingNotices(false);
+      }
+    };
+
+    fetchNoticesSequentially();
   }, []);
 
   useEffect(() => {

--- a/src/pages/Main/HomePage.tsx
+++ b/src/pages/Main/HomePage.tsx
@@ -119,7 +119,7 @@ export default function HomePage() {
 
   return (
     <div className="absolute left-[315px] right-[42px] opacity-100 max-xl:static max-xl:w-full">
-      <Header pageTitle="책모 홈" customClassName="mt-[30px] pl-6" />
+      <Header pageTitle="책모 홈" customClassName="my-[30px] pl-6" />
 
       <div
         ref={scrollContainerRef}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 공지 조회를 클럽별 순차 요청으로 변경하고 요청 간 150ms 지연을 추가하여 안정성 향상.
  - 개별 클럽 공지 실패 시 전체 중단 없이 로그 후 계속 진행.
  - 클럽/공지 가져오기 실패 로그를 보강하고 로딩 상태 처리 일관성 개선.
  - 책 이야기 데이터 로직은 변경 없음.

- **Style**
  - 헤더 여백을 mt에서 my로 조정해 상하 간격 개선.
  - 공지/책 이야기 로딩·에러 문구에 좌측 패딩(pl-2) 추가로 정렬 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->