### PR TITLE
[Fix] ToDoList 내용 참고

### DIFF
--- a/src/components/Search/BookSearch.tsx
+++ b/src/components/Search/BookSearch.tsx
@@ -90,7 +90,7 @@ export default function BookSearch({
         >
           {Searchbooks.map((SearchBook) => (
             <div key={SearchBook.isbn}>
-              <div className = "flex h-[215px] border-2 border-[var(--sub-color-2-brown,#EAE5E2)] rounded-2xl bg-[var(--White,#FFF)] shadow-sm  hover:shadow-lg hover:scale-[1.03]">
+              <div className = "min-w-[300px] flex h-[215px] border-2 border-[var(--sub-color-2-brown,#EAE5E2)] rounded-2xl bg-[var(--White,#FFF)] shadow-sm ransition-transform duration-300  hover:shadow-lg hover:scale-[1.03]">
                   {/* 좌측 */}
                 <div className="flex-1 flex p-[10px] gap-[20px]">
                   {/* 썸네일 */}

--- a/src/components/Search/SearchedBookModal.tsx
+++ b/src/components/Search/SearchedBookModal.tsx
@@ -73,8 +73,7 @@ export default function SearchedBookModal({ isOpen, onClose, searchBook}: Props)
               <button
                 className="rounded-lg px-4 py-2 bg-[var(--button-brown,#A6917E)] text-white hover:brightness-90"
                 onClick={() => {
-
-                  navigate(`/bookstory/${searchBook.isbn}/write`);
+                  navigate(`/bookstory/${searchBook.isbn}/write`, { state: { book: searchBook } });
                   onClose();
                 }}
               >

--- a/src/components/Shelf/ReviewSection.tsx
+++ b/src/components/Shelf/ReviewSection.tsx
@@ -175,7 +175,7 @@ export default function ReviewSection({
             key={review.bookReviewId}
             className="flex py-2 shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]  hover:shadow-md"
           >
-            <div className="flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]" onClick={() => {
+            <div className="flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px] cursor-pointer" onClick={() => {
                     navigate(`/info/others/${review.authorInfo.nickname}`)
                   }}>
               <img

--- a/src/components/Shelf/ReviewSection.tsx
+++ b/src/components/Shelf/ReviewSection.tsx
@@ -144,7 +144,7 @@ export default function ReviewSection({
       </span>
 
       {/* 등록 영역 */}
-      <div className="flex py-2 shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] w-full mb-3  hover:shadow-md">
+      <div className="flex py-2 shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] w-full mb-3  transition-transform duration-300 hover:shadow-md">
         <div className="flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]">
           <img
             src={currentUser.profileImageUrl}

--- a/src/components/Shelf/ReviewSection.tsx
+++ b/src/components/Shelf/ReviewSection.tsx
@@ -16,6 +16,7 @@ import LongtermChatInput from '../LongtermChatInput';
 import { getStarIcon } from './getStarIcon';
 import StarSelector from '../BookRecommend/StarSelector';
 import Modal, { type ModalButton } from '../Modal';
+import { useNavigate } from 'react-router-dom';
 
 export default function ReviewSection({
   meetingId,
@@ -26,6 +27,7 @@ export default function ReviewSection({
   currentUser: { nickname: string; profileImageUrl: string };
   size: number;
 }) {
+  const navigate = useNavigate();
   const [newRating, setNewRating] = useState<number>(0);
   const [editRating, setEditRating] = useState<number>(0);
   const [ReviewList, setReviewList] = useState<ReviewItem[]>([]);
@@ -173,7 +175,9 @@ export default function ReviewSection({
             key={review.bookReviewId}
             className="flex py-2 shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)]  hover:shadow-md"
           >
-            <div className="flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]">
+            <div className="flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]" onClick={() => {
+                    navigate(`/info/others/${review.authorInfo.nickname}`)
+                  }}>
               <img
                 src={
                   review.authorInfo.profileImageUrl ||

--- a/src/pages/Admin/MemberAdminPage.tsx
+++ b/src/pages/Admin/MemberAdminPage.tsx
@@ -50,7 +50,7 @@ const MemberAdminPage = () => {
       ]);
       setInfoOpen(true);
     } else if (nextStatus == 'MEMBER') {
-      setInfoTitle("가입을 승인하시겠습니까?");
+      setInfoTitle("정말로 이 회원의 운영진 역할을 해제하시겠습니까?");
       setInfoButtons([
         { label: "확인", onClick: () => {mutate({ memberId, status: nextStatus }); setInfoOpen(false);}},
         { label: "취소", onClick: () => setInfoOpen(false) , variant: "outline" },
@@ -98,26 +98,28 @@ const MemberAdminPage = () => {
 
             {/* 버튼들 */}
             <div>
-              {member.clubMemberStatus !== 'STAFF' &&
+              {(member.clubMemberStatus !== 'STAFF' &&
                 <div className="flex gap-2">
-                  <button className="px-4 py-1.5 rounded-full text-sm bg-[#EFF5ED] text-[#367216] border border-[#90D26D] hover:bg-[#90D26D] hover:text-white "
-                  onClick={() => handleMemberStatus(member.clubMemberId, 'STAFF')}>
-                    운영진 역할 부여
-                  </button>
-
-                  <button className="w-[90px] px-4 py-1.5 rounded-full text-sm bg-[#EFF5ED] text-[#367216] border border-[#90D26D] hover:bg-[#90D26D] hover:text-white "
+                    
+                  <button className="w-[90px] px-4 py-1.5 rounded-full text-sm  border border-[#90D26D] bg-[#EFF5ED] text-[#367216] hover:bg-[#90D26D] hover:text-white "
                   onClick={() => handleMemberStatus(member.clubMemberId, 'BLOCKED')}>
                     삭제하기
                   </button>
+
+                  <button className="px-4 py-1.5 rounded-full text-sm border border-[#90D26D] bg-[#EFF5ED] text-[#367216] hover:bg-[#90D26D] hover:text-white cursor-pointer"
+                  onClick={() => handleMemberStatus(member.clubMemberId, 'STAFF')}>
+                    운영진 승격
+                  </button>
                 </div>
-              }
-              {member.clubMemberStatus == 'STAFF' &&
+              )}
+              {member.clubMemberStatus == 'STAFF' && member.basicInfo.nickname !== localStorage.getItem('nickname') && (
                 <div className="flex gap-2">
-                  <div className="flex items-center justify-center w-[90px] px-4 py-1.5 rounded-full text-sm  border border-[#90D26D] bg-[#90D26D] text-white ">
-                    운영진
+                  <div className="px-4 py-1.5 rounded-full text-sm border border-[#f18282ff] bg-[#EFF5ED] text-[#f18282ff] hover:bg-[#f18282ff] hover:text-white cursor-pointer "
+                  onClick={() => handleMemberStatus(member.clubMemberId, 'MEMBER')}>
+                    운영진 해제
                   </div>
                 </div>
-              }                    
+              )}                    
             </div>
           </li>
         ))}

--- a/src/pages/Admin/MemberAdminPage.tsx
+++ b/src/pages/Admin/MemberAdminPage.tsx
@@ -87,7 +87,7 @@ const MemberAdminPage = () => {
             className="flex items-center justify-between pb-4"
           >
             {/* 유저 정보 */}
-            <div className="flex items-center " onClick={() => {
+            <div className="flex items-center cursor-pointer" onClick={() => {
                     navigate(`/info/others/${member.basicInfo.nickname}`)
                   }}>
               <img src = {member.basicInfo.profileImageUrl || "/public/assets/ix_user-profile-filled.svg"} alt="profile" className="w-12 h-12 rounded-full mr-4" />

--- a/src/pages/Admin/MemberAdminPage.tsx
+++ b/src/pages/Admin/MemberAdminPage.tsx
@@ -87,7 +87,9 @@ const MemberAdminPage = () => {
             className="flex items-center justify-between pb-4"
           >
             {/* 유저 정보 */}
-            <div className="flex items-center">
+            <div className="flex items-center " onClick={() => {
+                    navigate(`/info/others/${member.basicInfo.nickname}`)
+                  }}>
               <img src = {member.basicInfo.profileImageUrl || "/public/assets/ix_user-profile-filled.svg"} alt="profile" className="w-12 h-12 rounded-full mr-4" />
               <span className="font-['Pretendard'] text-[18px] font-semibold leading-[135%] text-gray-800">
                 {member.basicInfo.nickname}

--- a/src/pages/Admin/MemberBlockPage.tsx
+++ b/src/pages/Admin/MemberBlockPage.tsx
@@ -87,7 +87,7 @@ const MemberBlockPage = () => {
       {Member.map((member) => (
         <div key={member.clubMemberId} className="px-4 mb-10 ">
           <div className="flex justify-between mb-4">
-            <div className="flex items-center">
+            <div className="flex items-center" onClick={() => {navigate(`/info/others/${member.basicInfo.nickname}`)}}>
               <img src={member.basicInfo.profileImageUrl || "/public/assets/ix_user-profile-filled.svg"} alt="profile" className="w-12 h-12 rounded-full mr-4" />
               <div>
                 <p className="text-lg font-semibold">{member.basicInfo.nickname}</p>

--- a/src/pages/Admin/MemberBlockPage.tsx
+++ b/src/pages/Admin/MemberBlockPage.tsx
@@ -87,7 +87,7 @@ const MemberBlockPage = () => {
       {Member.map((member) => (
         <div key={member.clubMemberId} className="px-4 mb-10 ">
           <div className="flex justify-between mb-4">
-            <div className="flex items-center" onClick={() => {navigate(`/info/others/${member.basicInfo.nickname}`)}}>
+            <div className="flex items-center cursor-pointer" onClick={() => {navigate(`/info/others/${member.basicInfo.nickname}`)}}>
               <img src={member.basicInfo.profileImageUrl || "/public/assets/ix_user-profile-filled.svg"} alt="profile" className="w-12 h-12 rounded-full mr-4" />
               <div>
                 <p className="text-lg font-semibold">{member.basicInfo.nickname}</p>

--- a/src/pages/Admin/RegisterAdminPage.tsx
+++ b/src/pages/Admin/RegisterAdminPage.tsx
@@ -85,7 +85,7 @@ const RegisterAdminPage = () => {
       {Member.map((member) => (
         <div key={member.clubMemberId} className="px-4 mb-10 ">
           <div className="flex justify-between mb-4">
-            <div className="flex items-center" onClick={() => {navigate(`/info/others/${member.basicInfo.nickname}`)}}>
+            <div className="flex items-center cursor-pointer" onClick={() => {navigate(`/info/others/${member.basicInfo.nickname}`)}}>
               <img src={member.basicInfo.profileImageUrl || "/public/assets/ix_user-profile-filled.svg"} alt="profile" className="w-12 h-12 rounded-full mr-4" />
               <div>
                 <p className="text-lg font-semibold">{member.basicInfo.nickname}</p>

--- a/src/pages/Admin/RegisterAdminPage.tsx
+++ b/src/pages/Admin/RegisterAdminPage.tsx
@@ -85,7 +85,7 @@ const RegisterAdminPage = () => {
       {Member.map((member) => (
         <div key={member.clubMemberId} className="px-4 mb-10 ">
           <div className="flex justify-between mb-4">
-            <div className="flex items-center">
+            <div className="flex items-center" onClick={() => {navigate(`/info/others/${member.basicInfo.nickname}`)}}>
               <img src={member.basicInfo.profileImageUrl || "/public/assets/ix_user-profile-filled.svg"} alt="profile" className="w-12 h-12 rounded-full mr-4" />
               <div>
                 <p className="text-lg font-semibold">{member.basicInfo.nickname}</p>

--- a/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
@@ -80,7 +80,7 @@ export default function ShelfDetailPage() {
             {/* 발제 리스트 */}
             <div className="flex flex-col gap-3 ">
               {topics!.map((topic : TopicItem) => (
-                <div key={topic.topicId} className="py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] hover:shadow-md">
+                <div key={topic.topicId} className="py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] ransition-transform duration-300  hover:shadow-md">
                   <div className= "flex h-[48px] ml-[12px] gap-[19px] items-center w-[222px] flex-shrink-0" >
                     <img src= {topic.authorInfo.profileImageUrl || '/assets/ix_user-profile-filled.svg'} className="w-[48px] h-[48px] rounded-full object-cover" />
                     <div className="font-semibold text-[15px] text-gray-800">{topic.authorInfo.nickname}</div>

--- a/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
@@ -81,7 +81,7 @@ export default function ShelfDetailPage() {
             <div className="flex flex-col gap-3 ">
               {topics!.map((topic : TopicItem) => (
                 <div key={topic.topicId} className="py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] ransition-transform duration-300  hover:shadow-md">
-                  <div className= "flex h-[48px] ml-[12px] gap-[19px] items-center w-[222px] flex-shrink-0 "onClick={() => {
+                  <div className= "flex h-[48px] ml-[12px] gap-[19px] items-center w-[222px] flex-shrink-0 cursor-pointer"onClick={() => {
                     navigate(`/info/others/${topic.authorInfo.nickname}`)
                   }} >
                     <img src= {topic.authorInfo.profileImageUrl || '/assets/ix_user-profile-filled.svg'} className="w-[48px] h-[48px] rounded-full object-cover" />

--- a/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
@@ -81,7 +81,9 @@ export default function ShelfDetailPage() {
             <div className="flex flex-col gap-3 ">
               {topics!.map((topic : TopicItem) => (
                 <div key={topic.topicId} className="py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] ransition-transform duration-300  hover:shadow-md">
-                  <div className= "flex h-[48px] ml-[12px] gap-[19px] items-center w-[222px] flex-shrink-0" >
+                  <div className= "flex h-[48px] ml-[12px] gap-[19px] items-center w-[222px] flex-shrink-0 "onClick={() => {
+                    navigate(`/info/others/${topic.authorInfo.nickname}`)
+                  }} >
                     <img src= {topic.authorInfo.profileImageUrl || '/assets/ix_user-profile-filled.svg'} className="w-[48px] h-[48px] rounded-full object-cover" />
                     <div className="font-semibold text-[15px] text-gray-800">{topic.authorInfo.nickname}</div>
                   </div>

--- a/src/pages/BookClub/Shelf/ShelfHomePage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfHomePage.tsx
@@ -14,7 +14,7 @@ export default function   ShelfHomePage() {
 
   const [Cursor, setCursor]  = useState<number | null | undefined>(null);
   const [Generation, setGeneration] = useState<number | undefined>(undefined);
-  const [maxGeneration, setMaxGeneration] = useState<number>(0);
+  const [maxGeneration, setMaxGeneration] = useState<number>(1);
 
   const Req : ShelfHomeRequest = {
       clubId: Number(bookclubId), 
@@ -61,21 +61,10 @@ export default function   ShelfHomePage() {
   }, [hasNext, isLoading, nextCursor]);
 
   if ( isError ) return <p className="text-red-500">Error: {error?.message}</p>;
-  if(ShelfList.length === 0) {
-    return (
-      
-      <div className="flex flex-col w-full h-[120px] flex">
-        <Header pageTitle={'책장'} 
-          customClassName="w-full px-10 mt-[30px]"
-        />
-        <p className="mt-20 text-[#969696] text-center">책장이 비어있습니다.</p>
-      </div>
-    );
-  }
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen ">
       {/* 메인 컨텐츠 자리 */}
-      <div className="">
+      <div className="w-full">
         {/* 헤더 자리 */}
         <Header pageTitle={'책장'} 
           customClassName="px-10 mt-[30px]"
@@ -114,10 +103,23 @@ export default function   ShelfHomePage() {
                           absolute top-1/2 right-[12px] -translate-y-1/2"/>
            </div>
           </div>
-          {/* 책장 리스트 */}
-          <div className="pt-[18px] grid grid-cols-1 gap-x-1 gap-y-2 lg:grid-cols-2 lg:gap-x-2 lg:gap-y-4 xl:grid-cols-3 lg:gap-x-3 lg:gap-y-6 content-start overflow-y-auto h-[calc(100vh-171px)] overscroll-none px-10"  style={{ msOverflowStyle: 'none', scrollbarWidth: 'none' }}>
-                {ShelfList.map((Shelf) => (
-              <Link key={Shelf.meetingInfo.meetingId} to={`${location.pathname}/${Shelf.meetingInfo.meetingId}`} className="flex h-[260px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] hover:shadow-lg hover:scale-[1.03] transition-shadow block">
+          {/* 책장: 비었을 때 */}
+          {!ShelfList || ShelfList.length === 0 ? (
+            <div className="flex flex-col w-full h-[120px] px-10">
+              <p className="mt-20 text-[#969696] text-center">책장이 비어있습니다.</p>
+            </div>
+          ) : (
+            /* 책장: 목록 있을 때만 그리드/무한스크롤 포함 */
+            <div
+              className="pt-[18px] grid grid-cols-1 gap-x-1 gap-y-2 lg:grid-cols-2 lg:gap-x-2 lg:gap-y-4 xl:grid-cols-3 lg:gap-x-3 lg:gap-y-6 content-start overflow-y-auto h-[calc(100vh-171px)] overscroll-none px-10"
+              style={{ msOverflowStyle: "none", scrollbarWidth: "none" }}
+            >
+              {ShelfList.map((Shelf) => (
+                <Link
+                  key={Shelf.meetingInfo.meetingId}
+                  to={`${location.pathname}/${Shelf.meetingInfo.meetingId}`}
+                  className="flex h-[260px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] hover:shadow-lg hover:scale-[1.03] transition-shadow block"
+                >
                   {/* 왼쪽 */}
                   <div className="w-[156px] flex-shrink-0 h-full rounded-2xl overflow-hidden bg-gray-200">
                     <img
@@ -127,76 +129,97 @@ export default function   ShelfHomePage() {
                     />
                   </div>
 
-                {/* 오른쪽: 남은 공간을 모두 차지 */}
-                <div className="flex flex-col h-full flex-1 min-h-0 overflow-hidden">
-
-                  {/* 1) 제목 */}
-                  <p className="flex-1 min-w-0 flex-none h-[17px] text-[14px] font-[Pretendard] font-semibold  leading-[135%] text-[var(--Gray1,#2C2C2C)] truncate ">
-                    {Shelf.bookInfo.title}
-                  </p>
-                  {/* 2) 저자 · 번역자 */}
-                  <p className="flex-1 min-w-0 flex-none h-[17px] text-[12px] text-[#8D8D8D] font-[Pretendard] font-medium leading-[145%] truncate ">
-                    {Shelf.bookInfo.author} 지음
-                  </p>
-                  {/* 3) term, tag  (10px 아래 여백) */}
-                  <div className="flex mt-[10px] gap-2 ">
-                    <p className=" h-6 w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-white">
-                      {Shelf.meetingInfo.generation}기
+                  {/* 오른쪽 */}
+                  <div className="flex flex-col h-full flex-1 min-h-0 overflow-hidden">
+                    {/* 제목 */}
+                    <p className="flex-1 min-w-0 flex-none h-[17px] text-[14px] font-[Pretendard] font-semibold leading-[135%] text-[var(--Gray1,#2C2C2C)] truncate">
+                      {Shelf.bookInfo.title}
                     </p>
-                    <p className="flex-shrink-0 h-6 px-3 min-w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-[12px]  text-white">
-                      {Shelf.meetingInfo.tag}
+                    {/* 저자 */}
+                    <p className="flex-1 min-w-0 flex-none h-[17px] text-[12px] text-[#8D8D8D] font-[Pretendard] font-medium leading-[145%] truncate">
+                      {Shelf.bookInfo.author} 지음
                     </p>
-                  </div>
 
-                {/* 링크 3개 */}
-                <div className="mt-[24px] flex flex-col">
-                  <Link to={`${location.pathname}/${Shelf.meetingInfo.meetingId}/topic`} state={{ bookTitle: Shelf.bookInfo.title }} className="block" onClick={(e) => { e.stopPropagation();}}>
-                    <div className=" w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between">
-                      <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C] items-center">
-                        발제</span>
-                      <img src="/assets/바로가기.svg" className="w-[24px] h-[24px]"/>
+                    {/* 기수, 태그 */}
+                    <div className="flex mt-[10px] gap-2">
+                      <p className="h-6 w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-white">
+                        {Shelf.meetingInfo.generation}기
+                      </p>
+                      <p className="flex-shrink-0 h-6 px-3 min-w-[54px] text-[12px] rounded-full bg-[#90D26D] flex items-center justify-center text-white">
+                        {Shelf.meetingInfo.tag}
+                      </p>
                     </div>
-                  </Link>
-                  <div  className="block">
-                    <Link to={`${location.pathname}/${Shelf.meetingInfo.meetingId}/score`} state={{ bookTitle: Shelf.bookInfo.title }} className="block" onClick={(e) => { e.stopPropagation();}}>
-                      <div className=" w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between">
-                      <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C] items-center">
-                        한줄평</span>
-                      <img src="/assets/바로가기.svg" className="w-[24px] h-[24px]"/>
-                    </div>
-                    </Link>
-                  </div>
-                  <div className="w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between"
-                  onClick={(e) => {
-                    setIsModalOpen(true);
-                    e.preventDefault();    
-                    e.stopPropagation();  
-                  }}>
-                  <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C] items-center">
-                    독서 후 활동
-                  </span>
-                  <img src="/assets/바로가기.svg" className="w-[24px] h-[24px]" />
-                </div>
-                </div>
-                  {/* 7) 평점별 별 아이콘 */}
-                  <div className="mt-[20px] flex items-center">
-                    {Array.from({ length: 5 }).map((_, i) => {
-                      const src = getStarIcon(Shelf.meetingInfo.averageRate, i);
-                      return <img key={i} src={src} alt="star" className="w-[24px] h-[24px]" />;
-                    })}
-                  </div>
-                </div>
 
-            </Link>
-            ))}
-            
-            {isLoading && <div className = "font-[Pretendard] font-semibold text-[16px] text-[#8D8D8D]">추가 불러오는 중…</div>}
-            <div ref={loadMoreRef} style={{ height: 1 }} />
-            <div className ="h-20"></div>
-            {Array.from({ length: 2 }).map((_, i) => (
-              <div key={`spacer-${i}`} className="invisible h-0"></div>
-            ))}
-          </div>
+                    {/* 링크 3개 */}
+                    <div className="mt-[24px] flex flex-col">
+                      <Link
+                        to={`${location.pathname}/${Shelf.meetingInfo.meetingId}/topic`}
+                        state={{ bookTitle: Shelf.bookInfo.title }}
+                        className="block"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <div className="w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between">
+                          <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C]">
+                            발제
+                          </span>
+                          <img src="/assets/바로가기.svg" className="w-[24px] h-[24px]" />
+                        </div>
+                      </Link>
+
+                      <Link
+                        to={`${location.pathname}/${Shelf.meetingInfo.meetingId}/score`}
+                        state={{ bookTitle: Shelf.bookInfo.title }}
+                        className="block"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <div className="w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between">
+                          <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C]">
+                            한줄평
+                          </span>
+                          <img src="/assets/바로가기.svg" className="w-[24px] h-[24px]" />
+                        </div>
+                      </Link>
+
+                      <div
+                        className="w-[128px] h-[24px] border-b-[1px] border-[var(--sub-color-2-brown,#EAE5E2)] flex items-center justify-between"
+                        onClick={(e) => {
+                          setIsModalOpen(true);
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                      >
+                        <span className="text-[12px] font-[Pretendard] font-medium leading-[145%] text-[#2C2C2C]">
+                          독서 후 활동
+                        </span>
+                        <img src="/assets/바로가기.svg" className="w-[24px] h-[24px]" />
+                      </div>
+                    </div>
+
+                    {/* 별점 */}
+                    <div className="mt-[20px] flex items-center">
+                      {Array.from({ length: 5 }).map((_, i) => {
+                        const src = getStarIcon(Shelf.meetingInfo.averageRate, i)
+                        return <img key={i} src={src} alt="star" className="w-[24px] h-[24px]" />
+                      })}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+
+              {isLoading && (
+                <div className="font-[Pretendard] font-semibold text-[16px] text-[#8D8D8D]">
+                  추가 불러오는 중…
+                </div>
+              )}
+              <div ref={loadMoreRef} style={{ height: 1 }} />
+              <div className="h-20"></div>
+              {Array.from({ length: 2 }).map((_, i) => (
+                <div key={`spacer-${i}`} className="invisible h-0"></div>
+              ))}
+            </div>
+          )}
+
+
           <Modal isOpen={isModalOpen} title={"독서 후 활동은 개발 예정입니다!"} buttons={[
             {
               label: '돌아가기',

--- a/src/pages/BookClub/Shelf/ShelfHomePage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfHomePage.tsx
@@ -118,7 +118,7 @@ export default function   ShelfHomePage() {
                 <Link
                   key={Shelf.meetingInfo.meetingId}
                   to={`${location.pathname}/${Shelf.meetingInfo.meetingId}`}
-                  className="flex h-[260px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] hover:shadow-lg hover:scale-[1.03] transition-shadow block"
+                  className="flex h-[260px] p-[20px] items-center gap-[20px] rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] bg-[var(--White,#FFF)] ransition-transform duration-300  hover:shadow-lg hover:scale-[1.03] transition-shadow block"
                 >
                   {/* 왼쪽 */}
                   <div className="w-[156px] flex-shrink-0 h-full rounded-2xl overflow-hidden bg-gray-200">

--- a/src/pages/BookClub/Shelf/ShelfHomePage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfHomePage.tsx
@@ -61,7 +61,17 @@ export default function   ShelfHomePage() {
   }, [hasNext, isLoading, nextCursor]);
 
   if ( isError ) return <p className="text-red-500">Error: {error?.message}</p>;
-
+  if(ShelfList.length === 0) {
+    return (
+      
+      <div className="flex flex-col w-full h-[120px] flex">
+        <Header pageTitle={'책장'} 
+          customClassName="w-full px-10 mt-[30px]"
+        />
+        <p className="mt-20 text-[#969696] text-center">책장이 비어있습니다.</p>
+      </div>
+    );
+  }
   return (
     <div className="flex h-screen">
       {/* 메인 컨텐츠 자리 */}

--- a/src/pages/BookClub/Shelf/TopicDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/TopicDetailPage.tsx
@@ -145,7 +145,7 @@ export default function ThemeDetailPage() {
             <div className="flex flex-col gap-3">
               {TopicList.map((Topic: TopicItem) => (
                 <div key={Topic.topicId} className="flex py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] hover:shadow-md">
-                    <div className= "flex-shrink-0 items-center w-[222px] h-[48px] ml-[12px] flex gap-[19px] mr-[15px] " onClick={() => {
+                    <div className= "flex-shrink-0 items-center w-[222px] h-[48px] ml-[12px] flex gap-[19px] mr-[15px] cursor-pointer" onClick={() => {
                       navigate(`/info/others/${Topic.authorInfo.nickname}`)
                     }}>
                       <img src= {Topic.authorInfo.profileImageUrl || '/assets/ix_user-profile-filled.svg'} className="w-[48px] h-[48px] rounded-full object-cover" />

--- a/src/pages/BookClub/Shelf/TopicDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/TopicDetailPage.tsx
@@ -131,7 +131,7 @@ export default function ThemeDetailPage() {
             <span className= "mt-[34px] mb-[22px] text-[18px] font-[Pretendard] font-medium leading-[135%] text-black">발제</span>
 
             {/* 등록 영역 */}
-            <div className=" py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] mb-3 hover:shadow-md">
+            <div className=" py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] mb-3   transition-transform duration-300 hover:shadow-md">
               <div className="flex-shrink-0 items-center w-[222px] h-[48px] ml-[12px] flex gap-[19px] mr-[15px]">
                 <img src={MyUrl} className="w-[48px] h-[48px] rounded-full object-cover"  alt="프로필"/>
                 <div className="flex-1 font-semibold text-[15px] text-gray-800">

--- a/src/pages/BookClub/Shelf/TopicDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/TopicDetailPage.tsx
@@ -145,7 +145,9 @@ export default function ThemeDetailPage() {
             <div className="flex flex-col gap-3">
               {TopicList.map((Topic: TopicItem) => (
                 <div key={Topic.topicId} className="flex py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] hover:shadow-md">
-                    <div className= "flex-shrink-0 items-center w-[222px] h-[48px] ml-[12px] flex gap-[19px] mr-[15px] " >
+                    <div className= "flex-shrink-0 items-center w-[222px] h-[48px] ml-[12px] flex gap-[19px] mr-[15px] " onClick={() => {
+                      navigate(`/info/others/${Topic.authorInfo.nickname}`)
+                    }}>
                       <img src= {Topic.authorInfo.profileImageUrl || '/assets/ix_user-profile-filled.svg'} className="w-[48px] h-[48px] rounded-full object-cover" />
                       <div className="font-semibold text-[15px] text-gray-800 mb-1">{Topic.authorInfo.nickname}</div>
                     </div>


### PR DESCRIPTION
ToDoList - 김기현
1. 책장 내용비었을 떄 대처 - 해결
2. 책장에서 발제,한줄평 등 이름 클릭시 그 사람 프로필로 이동 - 해결  
3. 모임 관리하기 - 회원관리 (프리스타일로 제작해라) - 해결 
4. 모임 관리하기 페이지 전체 이름 클릭시 그 사람 프로필로 이동 - 해결
5. 책검색, 책장, 발제, 한줄평 페이지 등등 호버하는 것들은 무조건 duration 넣기 - 해결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 검색 결과, 리뷰, 발제/토픽, 관리자 멤버 리스트 등에서 아바타/닉네임 영역 클릭 시 프로필 페이지로 바로 이동 가능
  - 책 이야기 작성 이동 시 선택한 도서 정보를 함께 전달해 작성 화면에서 즉시 활용
  - 책장 홈 빈 상태 안내 추가 및 무한 스크롤 로딩 표시 개선
- 스타일
  - 카드/리스트 아이템에 최소 너비와 커서, 호버 트랜지션 적용으로 시각적 피드백 강화
  - 관리자 페이지 버튼 문구 및 배치 개선, 인터랙션 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->