### PR TITLE
[Style] 모달 스타일+커서 포인터 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -77,10 +77,12 @@ const Header = ({
 
   return (
     <header
-      className={`${
-        customClassName ??
-        "fixed left-[264px] right-0 top-3 h-[56px] lg:px-13 px-4 md:px-8 "
-      } bg-white flex justify-between items-center z-50`}
+      className={`
+        w-full
+        mt-[30px] pb-[30px] bg-white flex justify-between items-center
+        border-b border-gray-200
+        ${customClassName ?? ""}
+      `}
     >
       {/* 타이틀 + 관리 버튼 */}
       <div className="flex items-center gap-3">

--- a/src/components/MyPageHeader.tsx
+++ b/src/components/MyPageHeader.tsx
@@ -62,15 +62,15 @@ const MyPageHeader = ({ title }: MyPageHeaderProps) => {
         title="정말 로그아웃 하시겠습니까?"
         buttons={[
           {
-            label: "취소",
-            onClick: () => setShowLogoutModal(false),
-            variant: "outline",
-          },
-          {
             label: "로그아웃",
             onClick: handleConfirmLogout,
             variant: "danger",
           },
+          {
+            label: "취소",
+            onClick: () => setShowLogoutModal(false),
+            variant: "outline",
+          },          
         ]}
         onBackdrop={() => setShowLogoutModal(false)}
       />

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -5,7 +5,7 @@ import type { NotificationPreviewItem } from "../types/header";
 export const TYPE_TEXT: Record<string, string> = {
   LIKE: "좋아요를 눌렀습니다.",
   COMMENT: "댓글을 남겼습니다.",
-  FOLLOW: "팔로우했습니다.",
+  FOLLOW: "구독했습니다.",
   CLUB_JOIN: "모임에 가입했습니다.",
 };
 

--- a/src/pages/Auth/ProfilePage.tsx
+++ b/src/pages/Auth/ProfilePage.tsx
@@ -360,9 +360,9 @@ const ProfilePage = () => {
                   </label>
                   <input
                     type="text"
-                    placeholder="50자 이내 (공란 가능)"
+                    placeholder="20자 이내 (공란 가능)"
                     value={bio}
-                    maxLength={50}
+                    maxLength={20}
                     onChange={(e) => setBio(e.target.value)}
                     className="w-full border-b border-[#DADFE3] px-2 py-2 focus:outline-none"
                   />

--- a/src/pages/Main/Info/My/MyGroupPage.tsx
+++ b/src/pages/Main/Info/My/MyGroupPage.tsx
@@ -124,9 +124,6 @@ const MyGroupPage = () => {
                         <div className="flex flex-col justify-between">
                           <div>
                             <div className="flex gap-2 mb-2 md:mb-3">
-                              <span className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2">
-                                7기
-                              </span>
                               {group.category.map((cat, idx) => (
                                 <span
                                   key={idx}
@@ -155,7 +152,7 @@ const MyGroupPage = () => {
                           }}
                           disabled={isLeaving}
                           className={`text-[#5C5C5C] border border-[#EAE5E2] rounded-full w-[90px] md:w-[105px] h-[32px] md:h-[35px] text-sm mt-auto 
-                            ${isLeaving ? "opacity-50 cursor-not-allowed" : "hover:bg-[#90D26D] hover:text-white"}`}
+                            ${isLeaving ? "opacity-50 cursor-not-allowed" : "hover:bg-[#90D26D] hover:text-white cursor-pointer"}`}
                         >
                           탈퇴하기
                         </button>
@@ -186,17 +183,18 @@ const MyGroupPage = () => {
         title="정말 탈퇴 하시겠습니까?"
         buttons={[
           {
+            label: "탈퇴",
+            onClick: confirmLeaveGroup,
+            variant: "danger",
+          },
+
+          {
             label: "취소",
             onClick: () => {
               setShowConfirmModal(false);
               setSelectedGroupId(null);
             },
             variant: "outline",
-          },
-          {
-            label: "탈퇴",
-            onClick: confirmLeaveGroup,
-            variant: "danger",
           },
         ]}
         onBackdrop={() => {

--- a/src/pages/Main/Info/My/MyHomePage.tsx
+++ b/src/pages/Main/Info/My/MyHomePage.tsx
@@ -144,8 +144,8 @@ const MyPage = () => {
                   </div>
                   <div className="bg-white rounded-xl border border-[#EAE5E2] p-5 shadow-sm min-h-[424px]">
                     <div className="grid grid-cols-2 gap-3">
-                      {[{ label: "팔로잉", list: followingList },
-                        { label: "팔로워", list: followerList }].map(({ label, list }) => (
+                      {[{ label: "구독중", list: followingList },
+                        { label: "구독자", list: followerList }].map(({ label, list }) => (
                         <div key={label}>
                           <p className="text-[#90D26D] text-[13px] mb-3">{label}</p>
                           {list.slice(0, 5).map((member) => (

--- a/src/pages/Main/Info/My/MyNotificationPage.tsx
+++ b/src/pages/Main/Info/My/MyNotificationPage.tsx
@@ -125,7 +125,7 @@ const MyNotificationPage = () => {
       case "LIKE":
         return `${item.senderNickname} 님이 내 책이야기에 좋아요를 눌렀습니다.`;
       case "FOLLOW":
-        return `${item.senderNickname} 님이 팔로잉을 시작했습니다.`;
+        return `${item.senderNickname} 님이 구독했습니다.`;
       case "JOIN_CLUB":
         return `${item.targetName}에 가입되셨습니다.`;
       default:

--- a/src/pages/Main/Info/My/MyProfilePage.tsx
+++ b/src/pages/Main/Info/My/MyProfilePage.tsx
@@ -229,7 +229,7 @@ const MyProfilePage = () => {
                 {isEditing ? (
                   <textarea
                     value={tempBio}
-                    onChange={(e) => e.target.value.length <= 30 && setTempBio(e.target.value)}
+                    onChange={(e) => e.target.value.length <= 20 && setTempBio(e.target.value)}
                     className="rounded-lg p-3 text-[#5C5C5C] w-full resize-none"
                     style={{
                       minHeight: "200px",
@@ -237,7 +237,7 @@ const MyProfilePage = () => {
                       border: "1px solid #F4F2F1",
                       outline: "none",
                     }}
-                    placeholder="소개글을 입력하세요 (최대 30자)"
+                    placeholder="소개글을 입력하세요 (최대 20자)"
                   />
                 ) : (
                   <div
@@ -248,12 +248,12 @@ const MyProfilePage = () => {
                       border: "1px solid #F4F2F1",
                     }}
                   >
-                    {bio || "소개글을 입력하세요 (최대 30자)"}
+                    {bio || "소개글을 입력하세요 (최대 20자)"}
                   </div>
                 )}
                 {/* 글자수 카운트 + 오류문구 */}
                 <div className="flex justify-between mt-1">
-                  <p className="text-sm text-[#8D8D8D]">{tempBio.length}/30</p>
+                  <p className="text-sm text-[#8D8D8D]">{tempBio.length}/20</p>
                   {isChanged && isEditing && (
                     <p className="text-sm text-[#FF8045]">수정내용을 저장해주세요!</p>
                   )}

--- a/src/pages/Main/Info/My/MyStoryPage.tsx
+++ b/src/pages/Main/Info/My/MyStoryPage.tsx
@@ -227,7 +227,7 @@ const MyStoryPage = () => {
                               e.stopPropagation();
                               handleDeleteClick(story.bookStoryId); 
                             }}
-                            className="text-[#A6917D] hover:text-[#90D26D]"
+                            className="text-[#A6917D] hover:text-[#90D26D] cursor-pointer"
                           >
                             <Trash2 size={24} />
                           </button>
@@ -237,7 +237,7 @@ const MyStoryPage = () => {
                                 e.stopPropagation();
                                 handleSave(story.bookStoryId);
                               }}
-                              className="text-[#A6917D] hover:text-[#90D26D]"
+                              className="text-[#A6917D] hover:text-[#90D26D] cursor-pointer"
                             >
                               <Save size={24} />
                             </button>
@@ -247,7 +247,7 @@ const MyStoryPage = () => {
                                 e.stopPropagation();
                                 handleEdit(story);
                               }}
-                              className="text-[#A6917D] hover:text-[#90D26D]"
+                              className="text-[#A6917D] hover:text-[#90D26D] cursor-pointer"
                             >
                               <Pencil size={24} />
                             </button>
@@ -289,11 +289,6 @@ const MyStoryPage = () => {
         onBackdrop={() => setDeleteTargetId(null)}
         buttons={[
           {
-            label: "아니요",
-            onClick: () => setDeleteTargetId(null),
-            variant: "outline",
-          },
-          {
             label: "네",
             onClick: () => {
               if (deleteTargetId !== null) {
@@ -302,6 +297,12 @@ const MyStoryPage = () => {
               }
             },
             variant: "danger",
+          },
+          
+          {
+            label: "아니요",
+            onClick: () => setDeleteTargetId(null),
+            variant: "outline",
           },
         ]}
       />

--- a/src/pages/Main/Info/My/MySubscriptionPage.tsx
+++ b/src/pages/Main/Info/My/MySubscriptionPage.tsx
@@ -135,8 +135,8 @@ const MySubscriptionPage = () => {
               }}
               className={`px-3 py-1 rounded-full text-[13px] font-medium text-white ${
                 user.following
-                  ? "bg-[#90D26D] hover:bg-[#7bb95b]"
-                  : "bg-[#8D8D8D] hover:bg-[#aaa]"
+                  ? "bg-[#90D26D] hover:bg-[#7bb95b] cursor-pointer"
+                  : "bg-[#8D8D8D] hover:bg-[#aaa] cursor-pointer"
               }`}
             >
               {user.following ? "삭제" : "구독"}
@@ -185,7 +185,7 @@ const MySubscriptionPage = () => {
                 e.stopPropagation();
                 handleRemoveFollower(user.nickname);
               }}
-              className="px-3 py-1 rounded-full text-[13px] font-medium text-white bg-[#90D26D] hover:bg-[#7bb95b]">
+              className="px-3 py-1 rounded-full text-[13px] font-medium text-white bg-[#90D26D] hover:bg-[#7bb95b] cursor-pointer">
               삭제
             </button>
           </div>


### PR DESCRIPTION
모달 스타일+커서 포인터 수정

- 탈퇴하기, 로그아웃, 삭제하기 모달 위 아래 위치만 수정
- 모두까기님이 구독했습니다! > 구독으로 팔로우 글씨바꾸기!
- 내 모임에 있는 7기 기수 태그 안 뜨게 빼기
- 팔로잉 팔로워도 구독중 구독자이름으로 바꾸기 
- 헤더 mb-30px mt-30px 통일로 다 넣어버리기
- 내 프로필 편집 20자 넘어가면 안써지게 막기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 헤더 고정 해제 및 여백/하단 보더 추가로 레이아웃 정돈.
  - 여러 액션 버튼에 커서 포인터 적용.
  - 모달 버튼 순서 조정(확인→취소 일관화).
  - 용어 변경: 팔로잉/팔로워 → 구독중/구독자, 알림 문구 ‘구독했습니다.’로 통일.
  - 프로필 소개 안내/카운터를 20자로 반영.

- 버그 수정
  - 그룹 화면의 중복 ‘탈퇴’ 버튼 제거.
  - 그룹 아이템의 불필요한 고정 배지 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->