### PR TITLE
[feat] 내 알림 리다이렉트 반영

### DIFF
--- a/src/pages/Main/Info/My/MyHomePage.tsx
+++ b/src/pages/Main/Info/My/MyHomePage.tsx
@@ -7,15 +7,20 @@ import {
   useMyFollowerQuery,
   useMyNotificationsQuery,
 } from "../../../../hooks/My/useMember";
+import { useQueryClient } from "@tanstack/react-query";
+import { readNotification } from "../../../../apis/My/memberApi";
 
 const MyPage = () => {
   const navigate = useNavigate();
+  const qc = useQueryClient();
 
   // API 호출 (모두 cursor 기반)
   const { data: profileData, error: profileError } = useMyProfileQuery();
   const { data: clubData, error: clubError } = useMyClubsQuery(null);
-  const { data: followingData, error: followingError } = useMyFollowingQuery(null);
-  const { data: followerData, error: followerError } = useMyFollowerQuery(null);
+  const { data: followingData, error: followingError } =
+    useMyFollowingQuery(null);
+  const { data: followerData, error: followerError } =
+    useMyFollowerQuery(null);
   const { data: notificationData, error: notificationError } =
     useMyNotificationsQuery(null);
 
@@ -41,7 +46,11 @@ const MyPage = () => {
 
   // 에러 발생 여부 (로그인 안된 경우도 포함)
   const hasError =
-    profileError || clubError || followingError || followerError || notificationError;
+    profileError ||
+    clubError ||
+    followingError ||
+    followerError ||
+    notificationError;
 
   return (
     <div className="relative w-full h-screen bg-[#FAFAFA] overflow-hidden">
@@ -124,7 +133,9 @@ const MyPage = () => {
                         <li
                           key={club.clubId}
                           className="py-3 cursor-pointer hover:bg-[#FAFAFA]"
-                          onClick={() => navigate(`/bookclub/${club.clubId}/home`)}
+                          onClick={() =>
+                            navigate(`/bookclub/${club.clubId}/home`)
+                          }
                         >
                           <p className="text-[#2C2C2C] font-medium text-[15px]">
                             {club.name}
@@ -148,15 +159,21 @@ const MyPage = () => {
                   </div>
                   <div className="bg-white rounded-xl border border-[#EAE5E2] p-5 shadow-sm min-h-[424px]">
                     <div className="grid grid-cols-2 gap-3">
-                      {[{ label: "구독중", list: followingList },
-                        { label: "구독자", list: followerList }].map(({ label, list }) => (
+                      {[
+                        { label: "구독중", list: followingList },
+                        { label: "구독자", list: followerList },
+                      ].map(({ label, list }) => (
                         <div key={label}>
-                          <p className="text-[#90D26D] text-[13px] mb-3">{label}</p>
+                          <p className="text-[#90D26D] text-[13px] mb-3">
+                            {label}
+                          </p>
                           {list.slice(0, 5).map((member) => (
                             <div
                               key={`${label}-${member.nickname}`}
                               className="bg-[#F4F2F1] rounded-lg px-3 py-3 mb-3 flex items-center gap-2 cursor-pointer hover:bg-[#FAFAFA]"
-                              onClick={() => navigate(`/info/others/${member.nickname}`)}
+                              onClick={() =>
+                                navigate(`/info/others/${member.nickname}`)
+                              }
                             >
                               {member.profileImageUrl ? (
                                 <img
@@ -164,7 +181,8 @@ const MyPage = () => {
                                   alt={`${member.nickname} 프로필`}
                                   className="w-6 h-6 rounded-full object-cover"
                                   onError={(e) =>
-                                    (e.currentTarget.src = "/assets/basic_profile.png")
+                                    (e.currentTarget.src =
+                                      "/assets/basic_profile.png")
                                   }
                                 />
                               ) : (
@@ -202,9 +220,22 @@ const MyPage = () => {
                         <li
                           key={item.notificationId}
                           className="flex justify-between items-center py-3 cursor-pointer hover:bg-[#FAFAFA]"
-                          onClick={() => {
-                            if (item.redirectPath) {
-                              navigate(item.redirectPath);
+                          onClick={async () => {
+                            try {
+                              // 읽음 처리 API 호출
+                              await readNotification(item.notificationId);
+
+                              // 캐시 무효화 → 새로 불러오기
+                              qc.invalidateQueries({
+                                queryKey: ["mypage", "notifications"],
+                              });
+
+                              // 경로 이동
+                              if (item.redirectPath) {
+                                navigate(item.redirectPath);
+                              }
+                            } catch (err) {
+                              console.error("알림 읽음 처리 실패:", err);
                             }
                           }}
                         >

--- a/src/pages/Main/Info/My/MyHomePage.tsx
+++ b/src/pages/Main/Info/My/MyHomePage.tsx
@@ -121,7 +121,11 @@ const MyPage = () => {
                   <div className="bg-white rounded-xl border border-[#EAE5E2] p-5 shadow-sm min-h-[424px]">
                     <ul className="divide-y divide-[#EAE5E2]">
                       {clubs.slice(0, 5).map((club) => (
-                        <li key={club.clubId} className="py-3">
+                        <li
+                          key={club.clubId}
+                          className="py-3 cursor-pointer hover:bg-[#FAFAFA]"
+                          onClick={() => navigate(`/bookclub/${club.clubId}/home`)}
+                        >
                           <p className="text-[#2C2C2C] font-medium text-[15px]">
                             {club.name}
                           </p>
@@ -151,7 +155,8 @@ const MyPage = () => {
                           {list.slice(0, 5).map((member) => (
                             <div
                               key={`${label}-${member.nickname}`}
-                              className="bg-[#F4F2F1] rounded-lg px-3 py-3 mb-3 flex items-center gap-2"
+                              className="bg-[#F4F2F1] rounded-lg px-3 py-3 mb-3 flex items-center gap-2 cursor-pointer hover:bg-[#FAFAFA]"
+                              onClick={() => navigate(`/info/others/${member.nickname}`)}
                             >
                               {member.profileImageUrl ? (
                                 <img
@@ -196,17 +201,26 @@ const MyPage = () => {
                       {notifications.slice(0, 5).map((item) => (
                         <li
                           key={item.notificationId}
-                          className="flex justify-between items-center py-3"
+                          className="flex justify-between items-center py-3 cursor-pointer hover:bg-[#FAFAFA]"
+                          onClick={() => {
+                            if (item.redirectPath) {
+                              navigate(item.redirectPath);
+                            }
+                          }}
                         >
                           <div>
-                            <p className="text-[#2C2C2C] text-[14px]">
+                            <p className="text-[14px] text-[#2C2C2C]">
                               {getNotificationMessage(item)}
                             </p>
                             <p className="text-[12px] text-[#8D8D8D] mt-1">
                               {item.createdAt}
                             </p>
                           </div>
-                          <div className="w-3 h-3 rounded-full bg-[#90D26D]"></div>
+                          <div
+                            className={`w-3 h-3 rounded-full ${
+                              item.read ? "bg-gray-300" : "bg-[#90D26D]"
+                            }`}
+                          ></div>
                         </li>
                       ))}
                     </ul>

--- a/src/pages/Main/Info/My/MyNotificationPage.tsx
+++ b/src/pages/Main/Info/My/MyNotificationPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react"; 
+import { useNavigate } from "react-router-dom";
 import MyPageHeader from "../../../../components/MyPageHeader";
 import Modal from "../../../../components/Modal"; 
 import type { NotificationItem, NotificationResponse } from "../../../../types/My/member";
@@ -14,6 +15,8 @@ const MyNotificationPage = () => {
     open: false,
     message: "",
   });
+
+  const navigate = useNavigate();
 
   // 무한스크롤 상태
   const [cursorId, setCursorId] = useState<number | null>(null);
@@ -109,10 +112,16 @@ const MyNotificationPage = () => {
   );
 
   const handleNotificationClick = async (n: NotificationItem) => {
+    // 1. 먼저 이동
+    if (n.redirectPath) {
+      navigate(n.redirectPath);
+    }
+
+    // 2. 뒤에서 읽음 처리 (실패해도 무시)
     if (!n.read) {
       try {
         await readNotification(n.notificationId);
-        //  읽음 처리 후 다시 불러오기
+        // 새로고침하지 않고 읽음 상태만 최신화하고 싶으면 아래 fetch는 빼도 됨
         fetchNotifications(null, false);
       } catch (err) {
         console.error("알림 읽음 처리 실패:", err);

--- a/src/pages/Main/Info/OthersProfilePage.tsx
+++ b/src/pages/Main/Info/OthersProfilePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Heart, Siren } from "lucide-react";
 import Modal from "../../../components/Modal"; 
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { getOtherProfile, followMember, getTargetBookStories } from "../../../apis/otherApi";
 import { toggleBookStoryLike } from "../../../apis/BookStory/bookstories";
 import type { OtherProfile } from "../../../types/other";
@@ -16,6 +16,7 @@ const OthersProfilePage = () => {
   const [isError, setIsError] = useState(false); 
 
   const { userId } = useParams<{ userId: string }>();
+  const navigate = useNavigate();
 
   /** 다른 사람 프로필 + 책이야기 불러오기 */
   useEffect(() => {
@@ -73,7 +74,6 @@ const OthersProfilePage = () => {
   const openReportModal = () => setShowReportModal(true);
   const handleReportConfirm = () => {
     setShowReportModal(false);
-    // 알림 메시지
     setShowReportCompleteModal(true);
   };
 
@@ -100,8 +100,8 @@ const OthersProfilePage = () => {
                       alt={`${profile.nickname} 프로필`}
                       className="w-[40px] h-[40px] rounded-full object-cover"
                       onError={(e) => {
-                              e.currentTarget.src = "/assets/basic_profile.png";
-                        }}
+                        e.currentTarget.src = "/assets/basic_profile.png";
+                      }}
                     />
                   ) : (
                     <img
@@ -109,8 +109,8 @@ const OthersProfilePage = () => {
                       alt="기본 프로필"
                       className="w-[40px] h-[40px] rounded-full bg-white object-cover scale-110"
                       onError={(e) => {
-                              e.currentTarget.src = "/assets/basic_profile.png";
-                        }}
+                        e.currentTarget.src = "/assets/basic_profile.png";
+                      }}
                     />
                   )}
                   <p className="text-[18px] font-semibold text-[#2C2C2C]">
@@ -155,7 +155,8 @@ const OthersProfilePage = () => {
               {books.map((book) => (
                 <div
                   key={book.bookStoryId}
-                  className="flex bg-white rounded-[12px] border border-[#EAE5E2] p-6"
+                  className="flex bg-white rounded-[12px] border border-[#EAE5E2] p-6 transition-transform duration-300 transform hover:shadow-lg hover:scale-103 cursor-pointer"
+                  onClick={() => navigate(`/bookstory/${book.bookStoryId}/detail`)}
                 >
                   {/* 책 이미지 */}
                   {book.bookInfo?.imgUrl ? (
@@ -220,7 +221,10 @@ const OthersProfilePage = () => {
                       {/* 좋아요 버튼 */}
                       <div
                         className="flex items-center gap-1 text-sm cursor-pointer"
-                        onClick={() => toggleLike(book.bookStoryId)}
+                        onClick={(e) => {
+                          e.stopPropagation(); 
+                          toggleLike(book.bookStoryId);
+                        }}
                       >
                         <Heart
                           size={24}
@@ -239,7 +243,10 @@ const OthersProfilePage = () => {
                       {/* 신고 버튼 */}
                       <div
                         className="flex items-center gap-1 text-[#2C2C2C] hover:text-[#90D26D] text-sm cursor-pointer"
-                        onClick={openReportModal}
+                        onClick={(e) => {
+                          e.stopPropagation(); 
+                          openReportModal();
+                        }}
                       >
                         <Siren size={26} />
                       </div>
@@ -258,15 +265,15 @@ const OthersProfilePage = () => {
         title="해당 책이야기를 신고하시겠습니까?"
         buttons={[
           {
-            label: "취소",
-            onClick: () => setShowReportModal(false),
-            variant: "outline",
-          },
-          {
             label: "신고",
             onClick: handleReportConfirm,
             variant: "danger",
           },
+          {
+            label: "취소",
+            onClick: () => setShowReportModal(false),
+            variant: "outline",
+          },         
         ]}
         onBackdrop={() => setShowReportModal(false)}
       />
@@ -283,7 +290,7 @@ const OthersProfilePage = () => {
           },
         ]}
       />
-    </div>
+    </div>  
   );
 };
 


### PR DESCRIPTION
- 내 알림 페이지에서 알림 선택해서 누르면 그 상세 알림으로 리다이렉트되게 수정
- 다른사람프로필에서 책이야기도 누르면 상세책이야기로 라우트+호버 추가
- 프로필 있는 곳은 다 누르면 프로필 상세페이지로 이동하게끔 수정
- 마이홈페이지에서 누를때마다 호버 살짝 추가 및 라우트 이동
- 마이홈페이지 읽은 알림 안 읽은 알림 연결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 내 모임/내 구독/내 알림 목록 아이템을 클릭해 해당 화면으로 이동하도록 네비게이션 추가
  - 알림 아이템 클릭 시 redirectPath가 있으면 해당 경로로 이동하고 읽음 처리 및 목록 갱신

- Style
  - 목록 아이템 및 카드에 hover 배경/커서 포인터/트랜지션(그림자, 확대) 효과 추가
  - 알림 읽음 표시점 색상 동적 적용(읽지 않음: 초록, 읽음: 회색)

- Bug Fixes
  - 카드 내부 버튼 클릭 시 카드 네비게이션이 발생하지 않도록 이벤트 전파 차단 (좋아요/신고)
  - 로그인/권한 오류 발생 시 로그인 필요 안내 표시 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->