### PR TITLE
[feat] 헤더 알림 연동 수정

### DIFF
--- a/src/apis/headerApi.ts
+++ b/src/apis/headerApi.ts
@@ -35,3 +35,8 @@ export const getNotificationPreview = async (
 
   return res.notifications;
 };
+
+/** 알림 읽음 처리: PATCH /api/notifications/{notificationId}/read */
+export async function readNotification(notificationId: number): Promise<void> {
+  return axiosInstance.patch(`/notifications/${notificationId}/read`);
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,8 +35,8 @@ const Header = ({
   // 프로필
   const { data: me, isPending: profilePending } = useMyProfileQuery();
 
-  // 알림 5개 불러오기
-  const { notifications, notiLoading } = useHeaderData(5);
+  // 알림 (항상 최대 5개 유지)
+  const { notifications, notiLoading, markAsRead } = useHeaderData(5);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -67,8 +67,9 @@ const Header = ({
     return `${n.senderNickname ?? ""} 님이 ${action}`;
   };
 
-  // 알림 클릭 시 notificationType 기준 redirect 처리
+  // 알림 클릭 시 → 읽음 처리 후 redirect
   const handleNotificationClick = (n: NotificationPreviewItem) => {
+    markAsRead(n.notificationId); // 읽음 처리
     if (n.redirectPath) {
       navigate(n.redirectPath);
       setIsModalOpen(false);

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
-import { getNotificationPreview } from "../apis/headerApi";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getNotificationPreview, readNotification } from "../apis/headerApi";
 import type { NotificationPreviewItem } from "../types/header";
 
 export const TYPE_TEXT: Record<string, string> = {
-  LIKE: "좋아요를 눌렀습니다.",
+  LIKE: "내 책이야기에 좋아요를 눌렀습니다.",
   COMMENT: "댓글을 남겼습니다.",
   FOLLOW: "구독했습니다.",
-  CLUB_JOIN: "모임에 가입했습니다.",
+  CLUB_JOIN: "모임에 가입되셨습니다.",
 };
 
 export const QK = {
@@ -16,6 +16,9 @@ export const QK = {
 
 /** 헤더 알림 데이터 훅 */
 export const useHeaderData = (size = 5) => {
+  const qc = useQueryClient();
+
+  // 알림 미리보기 조회
   const {
     data,
     isLoading: notiLoading,
@@ -25,9 +28,39 @@ export const useHeaderData = (size = 5) => {
     queryFn: () => getNotificationPreview(size),
   });
 
+  // 알림 읽음 처리
+  const { mutate: markAsRead } = useMutation({
+    mutationFn: (id: number) => readNotification(id),
+    onSuccess: async (_, id) => {
+      // 1. 캐시에서 해당 알림 제거
+      qc.setQueryData<NotificationPreviewItem[]>(QK.notiPreview(size), (old) =>
+        old ? old.filter((n) => n.notificationId !== id) : old
+      );
+
+      // 2. 최신 알림 다시 가져와서 부족하면 채워주기
+      const fresh = await getNotificationPreview(size);
+      qc.setQueryData(QK.notiPreview(size), (old: NotificationPreviewItem[] | undefined) => {
+        if (!old) return fresh;
+        // 이미 표시 중인 알림 + 새 알림 합쳐서 최대 size개
+        const merged = [...old];
+        fresh.forEach((n) => {
+          if (!merged.find((m) => m.notificationId === n.notificationId)) {
+            merged.push(n);
+          }
+        });
+        return merged.slice(0, size);
+      });
+
+      // 3. 다른 알림 관련 캐시도 invalidate
+      qc.invalidateQueries({ queryKey: ["notifications"] });
+      qc.invalidateQueries({ queryKey: ["mypage", "notifications"] });
+    },
+  });
+
   return {
     notifications: data ?? [],
     notiLoading,
     notiError,
+    markAsRead,
   };
 };


### PR DESCRIPTION
헤더 알림 연동 수정

- 종 모양 알림에서 알림을 읽으면 상세 페이지로 이동 이거를 누르면 종 모양 알림에서 사라지고 숫자에도 반영, 그리고 이게 알림전체페이지에, 마이홈페이지에도 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 헤더 알림 클릭 시, 먼저 읽음 처리 후 이동합니다.
  - 읽음 처리된 알림이 즉시 미리보기 목록에서 반영되며 최대 5개 미리보기를 유지합니다.

- 스타일
  - 알림 문구 수정:
    - 좋아요: “내 책이야기에 좋아요를 눌렀습니다.”
    - 모임 가입: “모임에 가입되셨습니다.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->