### PR TITLE
[feat] 내 모임 무한스크롤 구현

### DIFF
--- a/src/apis/headerApi.ts
+++ b/src/apis/headerApi.ts
@@ -35,3 +35,8 @@ export const getNotificationPreview = async (
 
   return res.notifications;
 };
+
+/** 알림 읽음 처리: PATCH /api/notifications/{notificationId}/read */
+export async function readNotification(notificationId: number): Promise<void> {
+  return axiosInstance.patch(`/notifications/${notificationId}/read`);
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,8 +35,8 @@ const Header = ({
   // 프로필
   const { data: me, isPending: profilePending } = useMyProfileQuery();
 
-  // 알림 5개 불러오기
-  const { notifications, notiLoading } = useHeaderData(5);
+  // 알림 (항상 최대 5개 유지)
+  const { notifications, notiLoading, markAsRead } = useHeaderData(5);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -67,8 +67,9 @@ const Header = ({
     return `${n.senderNickname ?? ""} 님이 ${action}`;
   };
 
-  // 알림 클릭 시 notificationType 기준 redirect 처리
+  // 알림 클릭 시 → 읽음 처리 후 redirect
   const handleNotificationClick = (n: NotificationPreviewItem) => {
+    markAsRead(n.notificationId); // 읽음 처리
     if (n.redirectPath) {
       navigate(n.redirectPath);
       setIsModalOpen(false);

--- a/src/hooks/My/useClubsInfinite.ts
+++ b/src/hooks/My/useClubsInfinite.ts
@@ -1,0 +1,23 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { getMyClubs } from "../../apis/My/memberApi";
+import type { ClubResponse } from "../../types/My/member";
+
+
+export function useMyClubsInfinite() {
+  return useInfiniteQuery<ClubResponse, Error>({
+    queryKey: ["my", "clubs"],
+
+    queryFn: ({ pageParam = null }) => {
+      const requestParams = pageParam as number | null;
+      console.log("🏷️ MyClubs API 요청:", requestParams);
+      return getMyClubs(requestParams);
+    },
+
+    initialPageParam: null,
+
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.nextCursor : undefined,
+
+    staleTime: 1000 * 60 * 5, // 5분 캐싱
+  });
+}

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
-import { getNotificationPreview } from "../apis/headerApi";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getNotificationPreview, readNotification } from "../apis/headerApi";
 import type { NotificationPreviewItem } from "../types/header";
 
 export const TYPE_TEXT: Record<string, string> = {
-  LIKE: "좋아요를 눌렀습니다.",
+  LIKE: "내 책이야기에 좋아요를 눌렀습니다.",
   COMMENT: "댓글을 남겼습니다.",
   FOLLOW: "구독했습니다.",
-  CLUB_JOIN: "모임에 가입했습니다.",
+  CLUB_JOIN: "모임에 가입되셨습니다.",
 };
 
 export const QK = {
@@ -16,6 +16,9 @@ export const QK = {
 
 /** 헤더 알림 데이터 훅 */
 export const useHeaderData = (size = 5) => {
+  const qc = useQueryClient();
+
+  // 알림 미리보기 조회
   const {
     data,
     isLoading: notiLoading,
@@ -25,9 +28,39 @@ export const useHeaderData = (size = 5) => {
     queryFn: () => getNotificationPreview(size),
   });
 
+  // 알림 읽음 처리
+  const { mutate: markAsRead } = useMutation({
+    mutationFn: (id: number) => readNotification(id),
+    onSuccess: async (_, id) => {
+      // 1. 캐시에서 해당 알림 제거
+      qc.setQueryData<NotificationPreviewItem[]>(QK.notiPreview(size), (old) =>
+        old ? old.filter((n) => n.notificationId !== id) : old
+      );
+
+      // 2. 최신 알림 다시 가져와서 부족하면 채워주기
+      const fresh = await getNotificationPreview(size);
+      qc.setQueryData(QK.notiPreview(size), (old: NotificationPreviewItem[] | undefined) => {
+        if (!old) return fresh;
+        // 이미 표시 중인 알림 + 새 알림 합쳐서 최대 size개
+        const merged = [...old];
+        fresh.forEach((n) => {
+          if (!merged.find((m) => m.notificationId === n.notificationId)) {
+            merged.push(n);
+          }
+        });
+        return merged.slice(0, size);
+      });
+
+      // 3. 다른 알림 관련 캐시도 invalidate
+      qc.invalidateQueries({ queryKey: ["notifications"] });
+      qc.invalidateQueries({ queryKey: ["mypage", "notifications"] });
+    },
+  });
+
   return {
     notifications: data ?? [],
     notiLoading,
     notiError,
+    markAsRead,
   };
 };

--- a/src/pages/Main/Info/My/MyGroupPage.tsx
+++ b/src/pages/Main/Info/My/MyGroupPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useState, useRef, useCallback } from "react";
 import MyPageHeader from "../../../../components/MyPageHeader";
 import { useNavigate } from "react-router-dom";
 import Modal from "../../../../components/Modal"; 
-import { useMyClubsQuery, useLeaveClub } from "../../../../hooks/My/useMember";
+import { useLeaveClub } from "../../../../hooks/My/useMember";
+import { useMyClubsInfinite } from "../../../../hooks/My/useClubsInfinite"; 
 import type { ClubItem } from "../../../../types/My/member";
 
 const MyGroupPage = () => {
@@ -15,8 +16,38 @@ const MyGroupPage = () => {
   const [isLeaving, setIsLeaving] = useState(false);
   const navigate = useNavigate();
 
-  const { data, isFetching, isError, refetch } = useMyClubsQuery(null);
+  // 무한 스크롤 쿼리
+  const {
+    data,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+    isError,
+  } = useMyClubsInfinite();
+
   const leaveClubMutation = useLeaveClub();
+
+  // IntersectionObserver Ref (타입 수정)
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const lastElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (isFetchingNextPage) return;
+
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage) {
+          fetchNextPage();
+        }
+      });
+
+      if (node) observerRef.current.observe(node);
+    },
+    [isFetchingNextPage, fetchNextPage, hasNextPage]
+  );
 
   const handleGroupClick = (id: number) => {
     navigate(`/bookclub/${id}/home`);
@@ -32,7 +63,6 @@ const MyGroupPage = () => {
         setSelectedGroupId(null);
         setShowConfirmModal(false);
         setShowResultModal(true);
-        refetch();
       },
       onError: (error: any) => {
         setIsLeaving(false);
@@ -43,23 +73,17 @@ const MyGroupPage = () => {
         const message = error?.response?.data?.message;
         const status = error?.response?.status;
 
-        // 기존 CLUB_4019 처리
         if (code === "CLUB_4019") {
           setErrorMessage(message || "운영진은 클럽을 탈퇴할 수 없습니다.");
-        }
-        // 추가된 상태 코드 처리
-        else if (status === 400) {
+        } else if (status === 400) {
           setErrorMessage(message || "잘못된 요청입니다.");
         } else if (status === 403) {
           setErrorMessage(message || "본인만 탈퇴할 수 있습니다.");
         } else if (status === 404) {
           setErrorMessage(message || "존재하지 않는 독서 모임입니다.");
-        }
-        // 그 외 기본 처리
-        else {
+        } else {
           setErrorMessage(message || "탈퇴에 실패했습니다.");
         }
-
         setShowErrorModal(true);
       },
     });
@@ -76,7 +100,9 @@ const MyGroupPage = () => {
     return <div className="p-6 text-red-500">모임 목록을 불러오는데 실패했습니다.</div>;
   }
 
-  const clubList = data?.clubList ?? [];
+  // page 타입 지정
+  const clubList =
+    data?.pages.flatMap((page: { clubList: ClubItem[] }) => page.clubList) ?? [];
 
   return (
     <div className="flex w-full h-screen bg-[#FAFAFA] overflow-hidden">
@@ -85,21 +111,22 @@ const MyGroupPage = () => {
       <div className="flex-1 flex flex-col pt-[96px] overflow-hidden">
         <main className="flex-1 overflow-y-auto">
           <div className="px-4 md:px-10 py-8 flex flex-col items-center min-h-full">
-            {/* case1: 모임이 없을 때 → 중앙에 표시 */}
-            {!isFetching && clubList.length === 0 ? (
+            {/* case1: 모임이 없을 때 */}
+            {clubList.length === 0 ? (
               <div className="flex flex-1 items-center justify-center">
-                <p className="text-gray-400">더 이상 모임이 없습니다.</p>
+                <p className="text-gray-400">모임이 없습니다.</p>
               </div>
             ) : (
-              /* 모임 목록 */
               <div className="w-full space-y-4 flex flex-col">
-                {clubList.map((group: ClubItem) => {
+                {clubList.map((group: ClubItem, idx: number) => {
                   const imgUrl = getImageUrl(group.profileImageUrl);
                   const isErrorImage = errorImages[group.clubId] || !imgUrl;
+                  const isLast = idx === clubList.length - 1;
 
                   return (
                     <div
                       key={group.clubId}
+                      ref={isLast ? lastElementRef : null} // 마지막 요소에 observer 연결
                       className="w-full flex flex-col md:flex-row justify-between bg-white border border-[#EAE5E2] rounded-[16px] px-4 md:px-6 py-4 shadow-sm cursor-pointer transition-transform duration-300 transform hover:shadow-lg hover:scale-105"
                       onClick={() => handleGroupClick(group.clubId)}
                     >
@@ -124,7 +151,7 @@ const MyGroupPage = () => {
                         <div className="flex flex-col justify-between">
                           <div>
                             <div className="flex gap-2 mb-2 md:mb-3">
-                              {group.category.map((cat, idx) => (
+                              {group.category.map((cat: string, idx: number) => (
                                 <span
                                   key={idx}
                                   className="min-w-[48px] md:min-w-[54px] h-[22px] md:h-[24px] rounded-[15px] bg-[#90D26D] text-white text-[12px] md:text-[13px] flex items-center justify-center px-2"
@@ -161,12 +188,11 @@ const MyGroupPage = () => {
                   );
                 })}
 
-                {isFetching && (
+                {isFetchingNextPage && (
                   <p className="text-center text-gray-400">불러오는 중...</p>
                 )}
 
-                {/* case2: 모임이 있을 때 > 끝에 표시 */}
-                {!isFetching && clubList.length > 0 && (
+                {!hasNextPage && (
                   <div className="w-full mt-4 flex justify-center">
                     <p className="text-gray-400">더 이상 모임이 없습니다.</p>
                   </div>
@@ -177,17 +203,12 @@ const MyGroupPage = () => {
         </main>
       </div>
 
-      {/* 탈퇴 확인 모달 */}
+      {/* 모달들 */}
       <Modal
         isOpen={showConfirmModal}
         title="정말 탈퇴 하시겠습니까?"
         buttons={[
-          {
-            label: "탈퇴",
-            onClick: confirmLeaveGroup,
-            variant: "danger",
-          },
-
+          { label: "탈퇴", onClick: confirmLeaveGroup, variant: "danger" },
           {
             label: "취소",
             onClick: () => {
@@ -203,31 +224,17 @@ const MyGroupPage = () => {
         }}
       />
 
-      {/* 결과 모달 */}
       <Modal
         isOpen={showResultModal}
         title="탈퇴되었습니다."
-        buttons={[
-          {
-            label: "확인",
-            onClick: () => setShowResultModal(false),
-            variant: "primary",
-          },
-        ]}
+        buttons={[{ label: "확인", onClick: () => setShowResultModal(false), variant: "primary" }]}
         onBackdrop={() => setShowResultModal(false)}
       />
 
-      {/* 에러 모달 */}
       <Modal
         isOpen={showErrorModal}
         title={errorMessage}
-        buttons={[
-          {
-            label: "확인",
-            onClick: () => setShowErrorModal(false),
-            variant: "primary",
-          },
-        ]}
+        buttons={[{ label: "확인", onClick: () => setShowErrorModal(false), variant: "primary" }]}
         onBackdrop={() => setShowErrorModal(false)}
       />
     </div>


### PR DESCRIPTION
내 모임 무한스크롤 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 헤더 알림 클릭 시 즉시 읽음 처리 지원
  - 내 모임 목록에 무한 스크롤 도입: 자동 다음 페이지 로드, 로딩 표시, 목록 종료 안내
  - 이미지 로드 실패 시 대체 표시로 안정성 향상
- Bug Fixes
  - 빈 목록/종료 상태 노출 조건 및 메시지 개선
  - 오류 메시지 응답 케이스 정비로 일관성 향상
- Style
  - 알림 관련 안내 문구 일부 다듬기 (자연스러운 표현으로 업데이트)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->