### PR TITLE
[feat] 발제 선택 기능 구현

### DIFF
--- a/src/apis/clubMeeting/meetingAPI.ts
+++ b/src/apis/clubMeeting/meetingAPI.ts
@@ -5,6 +5,8 @@ import type {
   MeetingListResult,
   TeamMemberResult,
   TeamTopicResult,
+  TopicSelect,
+  TopicSelectResponse,
   TotalTopicResult,
   UpdateClubMeeting,
 } from "../../types/clubMeeting";
@@ -87,6 +89,19 @@ export const getMeetingTeamMember = async (
 ): Promise<TeamMemberResult> => {
   const response: TeamMemberResult = await axiosInstance.get(
     `/meetings/${meetingId}/teams/${teamNumber}/members`
+  );
+  return response;
+};
+
+// 팀에서 Topic 선택/해제
+export const updateTopicSelect = async (
+  meetingId: number,
+  topicId: number,
+  data: TopicSelect
+): Promise<TopicSelectResponse> => {
+  const response: TopicSelectResponse = await axiosInstance.post(
+    `/meetings/${meetingId}/topics/${topicId}`,
+    data
   );
   return response;
 };

--- a/src/components/BookRecommend/BookRecommendDetailCard.tsx
+++ b/src/components/BookRecommend/BookRecommendDetailCard.tsx
@@ -57,9 +57,13 @@ const BookRecommendDetailCard = ({
                 src={authorInfo.profileImageUrl}
                 alt={authorInfo.nickname}
                 className="w-8 h-8 sm:w-10 sm:h-10 rounded-full object-cover bg-gray-200"
+                onClick={() => navigate(`/info/others/${authorInfo.nickname}`)}
               />
               <div>
-                <p className="font-semibold text-sm sm:text-base">{authorInfo.nickname}</p>
+                <p className="font-semibold text-sm sm:text-base"
+                  onClick={() => navigate(`/info/others/${authorInfo.nickname}`)}>
+                  {authorInfo.nickname}
+                </p>
                 <p className="text-[10px] sm:text-xs text-gray-500">건전한가즈앗코치</p>
               </div>
             </div>

--- a/src/components/BookRecommend/BookRecommendHeader.tsx
+++ b/src/components/BookRecommend/BookRecommendHeader.tsx
@@ -7,10 +7,9 @@ interface HeaderProps {
 const BookRecommendHeader = ({ author }: HeaderProps) => {
   return (
     <>
-      <div className="font-pretendard flex flex-row mt-5 mx-4">
+      <div className="flex flex-row mt-5 mx-4">
         <img
           src={author.profileImageUrl}
-          // src="/profile.png"
           className="mr-3 w-8 h-8
                         object-cover
                         rounded-full"

--- a/src/components/Meeting/TeamButtonList.tsx
+++ b/src/components/Meeting/TeamButtonList.tsx
@@ -15,16 +15,7 @@ const TeamButtonListComponent = ({
   const allTeams = Array.from({ length: 26 }, (_, i) => i + 1);
 
   return (
-    <div className="flex overflow-x-auto space-x-1 flex-shrink-0 ml-2 w-[230px] hide-scrollbar-container">
-      <style>{`
-        .hide-scrollbar-container {
-          -ms-overflow-style: none;
-          scrollbar-width: none;
-        }
-        .hide-scrollbar-container::-webkit-scrollbar {
-          display: none;
-        }
-      `}</style>
+    <div className="flex overflow-x-auto space-x-1 flex-shrink-0 ml-2 w-[230px]">
       <div className="flex space-x-1">
         {allTeams.map((teamNumber) => {
           const isSelected = selectedTeamNumbers.includes(teamNumber);

--- a/src/components/Meeting/TeamButtonList.tsx
+++ b/src/components/Meeting/TeamButtonList.tsx
@@ -1,10 +1,16 @@
 import { memo } from "react";
 
 interface TeamButtonListProps {
-  selectedTeams: number[];
+  selectedTeamNumbers: number[];
+  onSelect: (teamId: number) => void;
+  disabled: boolean
 }
 
-const TeamButtonListComponent = ({ selectedTeams }: TeamButtonListProps) => {
+const TeamButtonListComponent = ({
+  selectedTeamNumbers,
+  onSelect,
+  disabled
+}: TeamButtonListProps) => {
   const getTeamName = (num: number) => `${String.fromCharCode(64 + num)}조`;
   const allTeams = Array.from({ length: 26 }, (_, i) => i + 1);
 
@@ -21,15 +27,21 @@ const TeamButtonListComponent = ({ selectedTeams }: TeamButtonListProps) => {
       `}</style>
       <div className="flex space-x-1">
         {allTeams.map((teamNumber) => {
-          const isSelected = selectedTeams.includes(teamNumber);
+          const isSelected = selectedTeamNumbers.includes(teamNumber);
           return (
             <button
               key={teamNumber}
-              className={`px-4 py-1.5 border-2 text-xs rounded-xl whitespace-nowrap ${
-                isSelected
-                  ? "border-[#90D26D] bg-[#90D26D] text-white"
-                  : "border-[#90D26D]  bg-[#EFF5ED] text-[#3D4C35]"
-              }`}
+              onClick={(e) => {
+                if (disabled) {
+                  e.preventDefault();
+                  return;
+                }
+                onSelect(teamNumber);
+              }}
+              className={`px-4 py-1.5 border-2 text-xs rounded-xl whitespace-nowrap ${isSelected
+                ? "border-[#90D26D] bg-[#90D26D] text-white"
+                : "border-[#90D26D]  bg-[#EFF5ED] text-[#3D4C35]"
+                }`}
             >
               {getTeamName(teamNumber)}
             </button>

--- a/src/components/Meeting/TopicCard.tsx
+++ b/src/components/Meeting/TopicCard.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import type { AuthorDto } from "../../types/dto";
+import { useNavigate } from "react-router-dom";
 
 interface TopicCardProps {
   content: string;
@@ -7,12 +8,14 @@ interface TopicCardProps {
 }
 
 const TopicCardComponent = ({ content, authorInfo }: TopicCardProps) => {
+  const navigate = useNavigate();
   return (
     <div className="flex flex-1 min-w-[500px] items-center justify-between bg-[#F4F2F1] p-1 rounded-2xl border-2 border-[#EAE5E2]">
       <div className="flex items-center gap-3 flex-1 overflow-hidden">
         <img
           src={authorInfo.profileImageUrl}
           alt={authorInfo.nickname}
+          onClick={() => navigate(`/info/others/${authorInfo.nickname}`)}
           className="w-8 h-8 rounded-full bg-gray-200 shrink-0 ml-2"
         />
         <span className="text-black text-[12px] font-medium w-[120px] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap">

--- a/src/components/Meeting/TopicPreviewCard.tsx
+++ b/src/components/Meeting/TopicPreviewCard.tsx
@@ -1,17 +1,70 @@
 import { memo } from "react";
+import { useUpdateTopicSelect } from "../../hooks/useClubMeeting";
 import type { Topic } from "../../types/clubMeeting";
-import { TopicCard } from "./TopicCard";
 import { TeamButtonList } from "./TeamButtonList";
+import { TopicCard } from "./TopicCard";
+import { AxiosError } from "axios";
 
 interface TopicPreviewCardProps {
   preview: Topic;
+  meetingId?: number;
+  numberOfTeams?: number;
+  onUpdateSuccess?: (message: string) => void;
 }
 
-const TopicPreviewCardComponent = ({ preview }: TopicPreviewCardProps) => {
+const TopicPreviewCardComponent = ({
+  preview,
+  meetingId,
+  numberOfTeams,
+  onUpdateSuccess,
+}: TopicPreviewCardProps) => {
+  // 토픽 선택 기능 활성화 여부
+  const isSelectable =
+    typeof meetingId === "number" &&
+    typeof numberOfTeams === "number" &&
+    typeof onUpdateSuccess === "function";
+
+  const { mutate: updateTopic, isPending } = useUpdateTopicSelect(
+    meetingId ?? 0,
+    preview.topicId
+  );
+
+  const handleSelect = (teamId: number) => {
+    if (!isSelectable || isPending) return;
+
+    const isCurrentlySelected = preview.teamNumbers.includes(teamId);
+
+    updateTopic(
+      { isSelected: !isCurrentlySelected, teamNumber: teamId },
+      {
+        onSuccess: () => {
+          const message = !isCurrentlySelected
+            ? "발제가 선택되었습니다."
+            : "발제 선택이 해제되었습니다.";
+          onUpdateSuccess(message);
+        },
+        onError: (error) => {
+          let errorMessage = `오류가 발생했습니다: ${error.message}`;
+
+          if (error instanceof AxiosError && error.response?.data) {
+            errorMessage = error.response.data.message;
+          }
+          onUpdateSuccess(errorMessage);
+        },
+      }
+    );
+  };
+
   return (
     <li className="flex items-center justify-between">
       <TopicCard content={preview.content} authorInfo={preview.authorInfo} />
-      <TeamButtonList selectedTeams={preview.teamNumbers} />
+      <>
+        <TeamButtonList
+          selectedTeamNumbers={preview.teamNumbers}
+          onSelect={handleSelect}
+          disabled={!isSelectable}
+        />
+      </>
     </li>
   );
 };

--- a/src/components/Meeting/TopicPreviewSection.tsx
+++ b/src/components/Meeting/TopicPreviewSection.tsx
@@ -1,14 +1,21 @@
 import { memo } from "react";
+
 import type { Topic } from "../../types/clubMeeting";
 import { TopicPreviewCard } from "./TopicPreviewCard";
 
 interface TopicPreviewSectionProps {
   previews: Topic[];
+  meetingId?: number;
+  numberOfTeams?: number;
+  onUpdateSuccess?: (message: string) => void;
   onMoreClick?: () => void;
 }
 
 const TopicPreviewSectionComponent = ({
   previews,
+  meetingId,
+  numberOfTeams,
+  onUpdateSuccess,
   onMoreClick,
 }: TopicPreviewSectionProps) => {
   return (
@@ -26,7 +33,13 @@ const TopicPreviewSectionComponent = ({
       </div>
       <ul className="space-y-3">
         {previews.map((preview) => (
-          <TopicPreviewCard key={preview.topicId} preview={preview} />
+          <TopicPreviewCard
+            key={preview.topicId}
+            preview={preview}
+            meetingId={meetingId}
+            numberOfTeams={numberOfTeams}
+            onUpdateSuccess={onUpdateSuccess}
+          />
         ))}
       </ul>
     </section>

--- a/src/hooks/useClubMeeting.ts
+++ b/src/hooks/useClubMeeting.ts
@@ -12,6 +12,7 @@ import {
   getMeetingTeamTopic,
   getMeetingTopics,
   updateClubMeeting,
+  updateTopicSelect,
 } from "../apis/clubMeeting/meetingAPI";
 import type {
   CreateClubMeeting,
@@ -19,6 +20,7 @@ import type {
   MeetingListResult,
   TeamMemberResult,
   TeamTopicResult,
+  TopicSelect,
   TotalTopicResult,
   UpdateClubMeeting,
 } from "../types/clubMeeting";
@@ -97,5 +99,20 @@ export const useGetMeetingTeamMember = (
     queryKey: ["meetingTeamMembers", meetingId, teamNumber],
     queryFn: () => getMeetingTeamMember(meetingId, teamNumber),
     enabled: !!meetingId && !!teamNumber,
+  });
+};
+
+// 팀 발제 선택/해제
+export const useUpdateTopicSelect = (meetingId: number, topicId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<unknown, Error, TopicSelect>({
+    mutationFn: (data: TopicSelect) =>
+      updateTopicSelect(meetingId, topicId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["meetingTopics", meetingId] });
+      queryClient.invalidateQueries({
+        queryKey: ["meetingTeamTopic", meetingId],
+      });
+    },
   });
 };

--- a/src/pages/Meeting/MeetingDetailPage.tsx
+++ b/src/pages/Meeting/MeetingDetailPage.tsx
@@ -62,7 +62,7 @@ const MeetingDetailPage = () => {
   })();
 
   return (
-    <div className="mx-auto px-10">
+    <div className="mx-auto px-10 mb-10">
       <NonProfileHeader title={meetingInfo.title} />
       <section className="space-y-10">
         <div className="relative min-w-[700px]">
@@ -96,8 +96,8 @@ const MeetingDetailPage = () => {
             previews={topics.slice(0, 4)}
             onMoreClick={handleMoreTopics}
           />
+          {(topics.length === 0) && <hr className="h-[1px] bg-[#EAE5E2] border-0" />}
         </div>
-        <hr className="h-[1px] bg-[#EAE5E2] border-0" />
 
         {displayTeams.map((team) => (
           <div key={team.teamNumber} className="min-w-[700px]">
@@ -106,7 +106,7 @@ const MeetingDetailPage = () => {
               topics={(team.topics ?? []).slice(0, 4)}
               onViewAllClick={() => handleViewAllTeamTopics(team)}
             />
-            <hr className="h-[1px] bg-[#EAE5E2] border-0" />
+            {(team.topics.length === 0) && <hr className="h-[1px] bg-[#EAE5E2] border-0" />}
           </div>
         ))}
       </section>

--- a/src/pages/Meeting/MeetingDetailPage.tsx
+++ b/src/pages/Meeting/MeetingDetailPage.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useCallback, useEffect } from "react";
+import { useNavigate, useParams, useNavigationType } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import type { TeamTopic, Topic } from "../../types/clubMeeting";
 import { MeetingCard } from "../../components/Meeting/MeetingCard";
 import { TopicPreviewSection } from "../../components/Meeting/TopicPreviewSection";
@@ -10,7 +11,33 @@ import { useMeetingDetail } from "../../hooks/useClubMeeting";
 const MeetingDetailPage = () => {
   const navigate = useNavigate();
   const { meetingId } = useParams<{ meetingId: string }>();
-  const { data, isLoading, isError } = useMeetingDetail(Number(meetingId));
+  const { data, isLoading, isError, refetch } = useMeetingDetail(Number(meetingId));
+  const navigationType = useNavigationType();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (navigationType === 'POP') {
+      // 즉시 최신 데이터로 갱신
+      refetch();
+      // 목록/상세 캐시도 무효화하여 새로 고침 유도 (보조 안전장치)
+      if (meetingId) {
+        const mid = Number(meetingId);
+        queryClient.invalidateQueries({ queryKey: ["meeting", mid] });
+        queryClient.invalidateQueries({ queryKey: ["meetings"] });
+      }
+    }
+  }, [navigationType, refetch, meetingId, queryClient]);
+
+  useEffect(() => {
+    const handler = (e: PageTransitionEvent) => {
+      // bfcache에서 복원되거나, 단순히 페이지 표시될 때도 갱신
+      if (e.persisted || true) {
+        refetch();
+      }
+    };
+    window.addEventListener("pageshow", handler as any);
+    return () => window.removeEventListener("pageshow", handler as any);
+  }, [refetch]);
 
   const title = data?.meetingInfo.bookInfo?.title ?? "";
   const meetingTime = data?.meetingInfo?.meetingTime ?? "";

--- a/src/pages/Meeting/MeetingTopicListPage.tsx
+++ b/src/pages/Meeting/MeetingTopicListPage.tsx
@@ -1,35 +1,74 @@
 import { useParams, useLocation } from "react-router-dom";
+import { useState } from "react";
 import { TopicPreviewSection } from "../../components/Meeting/TopicPreviewSection";
 import { NonProfileHeader } from "../../components/NonProfileHeader";
-import { useGetMeetingTopics } from "../../hooks/useClubMeeting";
+import {
+  useGetMeetingTopics,
+  useMeetingDetail,
+} from "../../hooks/useClubMeeting";
 import { format, parseISO } from "date-fns";
+import Modal from "../../components/Modal";
 
 const MeetingTopicListPage = () => {
   const { meetingId } = useParams<{ meetingId: string }>();
   const location = useLocation();
-  const { title, meetingTime } = (location.state as { title: string; meetingTime: string }) || {};
+  const { title, meetingTime } =
+    (location.state as { title: string; meetingTime: string }) || {};
 
   const meetId = Number(meetingId ?? 0);
-  const dateStr = format(parseISO(meetingTime), "yyyy.MM.dd");
-  const headerTitle = `${dateStr} | ${title}`;
+
+  const dateStr = meetingTime
+    ? format(parseISO(meetingTime), "yyyy.MM.dd")
+    : "날짜 정보 없음";
+  const headerTitle = `${dateStr} | ${title || "모임 정보 없음"}`;
+
+  const [modalInfo, setModalInfo] = useState({ show: false, message: "" });
 
   const { data: topicsResult, isLoading: areTopicsLoading } =
     useGetMeetingTopics(meetId);
+  const { data: meetingDetails, isLoading: areDetailsLoading } =
+    useMeetingDetail(meetId);
 
-  if (areTopicsLoading) {
-    return <div>Loading...</div>;
+  const handleUpdateSuccess = (message: string) => {
+    setModalInfo({ show: true, message });
+  };
+
+  const closeModal = () => {
+    setModalInfo({ show: false, message: "" });
+  };
+
+  if (areTopicsLoading || areDetailsLoading) {
+    return <div className="p-4 text-center">로딩 중...</div>;
   }
 
-  if (!topicsResult) {
-    return <div>Error: Could not fetch meeting data.</div>;
+  if (!topicsResult || !meetingDetails) {
+    return <div className="p-4 text-center">모임 데이터를 불러올 수 없습니다.</div>;
   }
 
   const topics = topicsResult.topics;
+  const numberOfTeams = meetingDetails.teams.length;
 
   return (
     <div className="mx-auto px-10 space-y-5">
+      <Modal
+        isOpen={modalInfo.show}
+        title={modalInfo.message}
+        onBackdrop={closeModal}
+        buttons={[{ label: "확인", onClick: closeModal, variant: "primary" }]}
+      />
       <NonProfileHeader title={headerTitle} />
-      <TopicPreviewSection previews={topics} />
+      {topics.length > 0 ? (
+        <TopicPreviewSection
+          previews={topics}
+          meetingId={meetId}
+          numberOfTeams={numberOfTeams}
+          onUpdateSuccess={handleUpdateSuccess}
+        />
+      ) : (
+        <div className="text-center text-gray-500 pt-10">
+          <p>등록된 발제가 없습니다.</p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/types/clubMeeting.ts
+++ b/src/types/clubMeeting.ts
@@ -88,6 +88,11 @@ export type TeamMemberResult = {
   members: AuthorDto[];
 };
 
+export type TopicSelect = {
+  teamNumber: number;
+  isSelected: boolean;
+};
+
 // 독서 모임 발제와 선택한 팀 정보 전체 조회
 export type TotalTopicResponse = ApiResponse<TotalTopicResult>;
 
@@ -96,3 +101,6 @@ export type TeamTopicResponse = ApiResponse<TeamTopicResult>;
 
 // 팀 별 참여자 조회
 export type TeamMemberResponse = ApiResponse<TeamMemberResult>;
+
+// 팀에서 발제 선택/해제
+export type TopicSelectResponse = ApiResponse<TopicSelect>;


### PR DESCRIPTION
**MeetingTopicListPage & MeetingDetailPage**

https://github.com/user-attachments/assets/39d4917d-b7f4-44cb-bba1-82800d418fe0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 모임 내 팀별 발제 선택/해제 기능 추가(토픽 카드에서 직접 서버에 반영).
  - 선택/해제 성공·실패 메시지 표시용 모달 및 콜백 추가.
  - 모임 상세 데이터가 뒤로가기/페이지 복원 시 자동으로 새로고침되도록 개선.

- Improvements
  - 토픽 목록·헤더의 로딩·에러 문구 및 제목/날짜 폴백 보강.
  - 팀 버튼 리스트의 인터랙션(선택, 비활성화) 및 스크롤 표시 방식 단순화.

- Style
  - 페이지 하단 여백 추가 및 구분선 표시 조건 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->