### PR TITLE
[style] 마지막 수정?

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -108,7 +108,7 @@ const Header = ({
           <FaBell size={32} color="#90D26D" />
           {!notiLoading && unreadCount > 0 && (
             <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-[4px] rounded-full text-[11px] bg-[#90D26D] text-white flex items-center justify-center cursor-pointer">
-              {unreadCount}
+              {unreadCount >= 5 ? "5+" : unreadCount}
             </span>
           )}
         </button>

--- a/src/hooks/My/useMember.ts
+++ b/src/hooks/My/useMember.ts
@@ -20,6 +20,7 @@ import type {
   NotificationResponse,
 } from "../../types/My/member";
 import { QK } from "../useHeader";
+import type { NotificationPreviewItem } from "../../types/header";
 
 /* -------------------- 마이홈 전용 QK -------------------- */
  const QK_MY_HOME = {
@@ -124,10 +125,19 @@ export const useReadNotification = () => {
   const qc = useQueryClient();
   return useMutation<void, Error, number>({
     mutationFn: (id) => readNotification(id),
-    onSuccess: () => {
-      // 읽음 처리 후 알림 목록 새로고침
-      qc.invalidateQueries({ queryKey: [QK_MY_HOME.notifications] });
+    onSuccess: async (_, id) => {
+      // 1. 알림 페이지 invalidate (cursorId 붙은 쿼리까지 다 포함)
+      qc.invalidateQueries({ queryKey: [QK_MY_HOME.notifications], exact: false });
+
+      // 2. 헤더 알림 캐시에서 해당 알림 직접 업데이트
+      qc.setQueryData<NotificationPreviewItem[]>(QK.notiPreview(5), (old) =>
+        old ? old.map((n) =>
+          n.notificationId === id ? { ...n, read: true } : n
+        ) : old
+      );
+
+      // 3. 헤더도 서버 최신으로 갱신
+      qc.invalidateQueries({ queryKey: QK.notiPreview(5), exact:true });
     },
   });
 };
-  

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -32,16 +32,19 @@ export const useHeaderData = (size = 5) => {
   const { mutate: markAsRead } = useMutation({
     mutationFn: (id: number) => readNotification(id),
     onSuccess: async (_, id) => {
-      // 1. 캐시에서 해당 알림 제거
+      // 1. 캐시에서 해당 알림 read=true로 표시 (UI 즉시 반영)
       qc.setQueryData<NotificationPreviewItem[]>(QK.notiPreview(size), (old) =>
-        old ? old.filter((n) => n.notificationId !== id) : old
+        old
+          ? old.map((n) =>
+              n.notificationId === id ? { ...n, read: true } : n
+            )
+          : old
       );
 
       // 2. 최신 알림 다시 가져와서 부족하면 채워주기
       const fresh = await getNotificationPreview(size);
       qc.setQueryData(QK.notiPreview(size), (old: NotificationPreviewItem[] | undefined) => {
         if (!old) return fresh;
-        // 이미 표시 중인 알림 + 새 알림 합쳐서 최대 size개
         const merged = [...old];
         fresh.forEach((n) => {
           if (!merged.find((m) => m.notificationId === n.notificationId)) {
@@ -51,9 +54,10 @@ export const useHeaderData = (size = 5) => {
         return merged.slice(0, size);
       });
 
-      // 3. 다른 알림 관련 캐시도 invalidate
-      qc.invalidateQueries({ queryKey: ["notifications"] });
-      qc.invalidateQueries({ queryKey: ["mypage", "notifications"] });
+      // 3. Header와 알림 페이지 모두 강제 동기화 (refetchQueries로 즉시 서버 반영)
+      await qc.refetchQueries({ queryKey: QK.notiPreview(5) });
+      await qc.refetchQueries({ queryKey: ["notifications"], exact: false });
+      await qc.refetchQueries({ queryKey: ["mypage", "notifications"], exact: false });
     },
   });
 


### PR DESCRIPTION

- 전체 버튼 클릭시 커서포인터 사용
- 읽지 않은 알림 5개 넘어갈 시에 5+로 되게 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 헤더 알림 배지 표기를 개선했습니다: 읽지 않은 알림이 5개 미만이면 숫자, 5개 이상이면 “5+”로 표시됩니다.
- Bug Fixes
  - 알림을 읽음 처리하면 헤더 미리보기와 알림 페이지가 즉시 동기화되어 일관된 상태를 보여줍니다.
  - 읽은 항목이 미리보기에서 사라지지 않고 읽음 상태로 표시되며, 새로고침 없이 최신 상태가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->