### PR TITLE
[fix] 모임 조설정페이지 수정 + [style] 책장 프로필없을 때 기본프로필 

### DIFF
--- a/src/apis/clubMeeting/GetmeetingMember.ts
+++ b/src/apis/clubMeeting/GetmeetingMember.ts
@@ -1,0 +1,11 @@
+import type { GetMeetingMembersPayload, GetMeetingMembersResult } from "../../types/Meeting/GetmeetingMember";
+import { axiosInstance } from "../axiosInstance";
+
+export async function getMeetingMembers(
+  { meetingId, cursorId = null, size = 15 }: GetMeetingMembersPayload
+): Promise<GetMeetingMembersResult> {
+  return await axiosInstance.get(
+    `/meetings/${meetingId}/members`,
+    { params: { cursorId, size } }
+  );
+}

--- a/src/components/Meeting/teamMapper.ts
+++ b/src/components/Meeting/teamMapper.ts
@@ -1,4 +1,4 @@
-import type { ClubMember } from "../../types/Club/GetClubMembers";
+import type { MeetingMemberItem } from "../../types/Meeting/GetmeetingMember";
 import type { MeetingTeamMutateRequest } from "../../types/Meeting/MeetingTeamManage";
 
 // "1조" → 1, "A조" → 1, 그 외엔 groups 인덱스 기반
@@ -13,18 +13,16 @@ export function toTeamNumber(groupName: string, groups: string[]) {
   return idx >= 0 ? idx + 1 : 0;
 }
 
-export function buildMeetingTeamMutateRequest(  groupSelections: Record<string, ClubMember[]>,
-  groups: string[]
+export function buildMeetingTeamMutateRequest(
+  groupSelections: Record<string, MeetingMemberItem[]>
 ): MeetingTeamMutateRequest {
   return {
-    teamMemberDTOList: Object.entries(groupSelections)
-      .map(([groupName, members]) => ({
-        teamNumber: toTeamNumber(groupName, groups),
-        nicknameList: members.map(m => m.basicInfo.nickname)
-          
-
-      }))
-      .filter(x => x.teamNumber > 0 && x.nicknameList.length > 0)
+    teamMemberDTOList: Object.entries(groupSelections).map(([groupName, members]) => {
+      return {
+        teamNumber: toTeamNumber(groupName, Object.keys(groupSelections)),
+        nicknameList: members.map(member => member.memberInfo.nickname),
+      };
+    }),
 
   };
 }

--- a/src/components/Shelf/ReviewSection.tsx
+++ b/src/components/Shelf/ReviewSection.tsx
@@ -149,7 +149,7 @@ export default function ReviewSection({
       <div className="flex py-2 shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] w-full mb-3  transition-transform duration-300 hover:shadow-md">
         <div className="flex items-center justify-between h-[48px] w-[270px] flex-none ml-[12px] mr-[34px]">
           <img
-            src={currentUser.profileImageUrl}
+            src={currentUser.profileImageUrl || '/assets/ix_user-profile-filled.svg'}
             className="w-[48px] h-[48px] rounded-full object-cover"
             alt="프로필"
           />

--- a/src/hooks/Meeting/useGetInfinityMember.ts
+++ b/src/hooks/Meeting/useGetInfinityMember.ts
@@ -1,0 +1,29 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import type { GetMeetingMembersResult } from '../../types/Meeting/GetmeetingMember';
+import { getMeetingMembers } from '../../apis/clubMeeting/GetmeetingMember';
+
+
+const qk = {
+  meetingMembers: (meetingId: number, size: number) =>
+    ['meetingMembers', meetingId, size] as const,
+};
+
+export function useGetInfinityMember(meetingId: number, size = 15) {
+  return useInfiniteQuery<GetMeetingMembersResult, Error>({
+    queryKey: qk.meetingMembers(meetingId, size),
+    queryFn: ({ pageParam }) => {
+      const cursor = (pageParam ?? null) as number | null;
+      return getMeetingMembers({ meetingId, cursorId: cursor, size });
+    },
+    initialPageParam: null as number | null,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? lastPage.nextCursor : undefined,
+    select: (data) => {
+      const flatMembers = data.pages.flatMap(p => p.members);
+      const membership = data.pages[0]?.membership;
+      return { ...data, flatMembers, membership };
+    },
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+  });
+}

--- a/src/pages/BookClub/Shelf/ScoreDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ScoreDetailPage.tsx
@@ -15,12 +15,14 @@ export default function ScoreDetailPage() {
   useEffect(() => {
     const nickname = localStorage.getItem('nickname');
     const profileImageUrl = localStorage.getItem('profileImageUrl');
-    if(!nickname || !profileImageUrl) {
-      console.log("error처리")
-      return;
+    if(nickname) {
+      setMynickname(nickname);
+     
     }
-    setMynickname(nickname);
-    setUrl(profileImageUrl);
+    if(profileImageUrl) {
+      setUrl(profileImageUrl);
+    }
+
   }, []) 
 
   return (

--- a/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/ShelfDetailPage.tsx
@@ -20,12 +20,13 @@ export default function ShelfDetailPage() {
   useEffect(() => {
     const nickname = localStorage.getItem('nickname');
     const profileImageUrl = localStorage.getItem('profileImageUrl');
-    if(!nickname || !profileImageUrl) {
-      console.log("error처리")
-      return;
+    if(nickname) {
+      setMynickname(nickname);
+     
     }
-    setMynickname(nickname);
-    setUrl(profileImageUrl);
+    if(profileImageUrl) {
+      setUrl(profileImageUrl);
+    }
   }, []) 
 
   if (isLoading) return <div className = "font-[Pretendard] font-semibold text-[16px] text-[#8D8D8D]">로딩 중…</div>

--- a/src/pages/BookClub/Shelf/TopicDetailPage.tsx
+++ b/src/pages/BookClub/Shelf/TopicDetailPage.tsx
@@ -35,12 +35,13 @@ export default function ThemeDetailPage() {
   useEffect(() => {
     const nickname = localStorage.getItem('nickname');
     const profileImageUrl = localStorage.getItem('profileImageUrl');
-    if(!nickname || !profileImageUrl) {
-      console.log("error처리")
-      return;
+    if(nickname) {
+      setMynickname(nickname);
+     
     }
-    setMynickname(nickname);
-    setUrl(profileImageUrl);
+    if(profileImageUrl) {
+      setUrl(profileImageUrl);
+    }
   }, []) 
   
   useEffect(() => {
@@ -133,7 +134,7 @@ export default function ThemeDetailPage() {
             {/* 등록 영역 */}
             <div className=" py-2 flex shadow rounded-2xl border-2 border-[var(--sub-color-2-brown,#EAE5E2)] mb-3   transition-transform duration-300 hover:shadow-md">
               <div className="flex-shrink-0 items-center w-[222px] h-[48px] ml-[12px] flex gap-[19px] mr-[15px]">
-                <img src={MyUrl} className="w-[48px] h-[48px] rounded-full object-cover"  alt="프로필"/>
+                <img src={MyUrl || '/assets/ix_user-profile-filled.svg'} className="w-[48px] h-[48px] rounded-full object-cover"  alt="프로필"/>
                 <div className="flex-1 font-semibold text-[15px] text-gray-800">
                   {Mynickname}
                 </div>

--- a/src/pages/Meeting/DetailMeatingManagePage.tsx
+++ b/src/pages/Meeting/DetailMeatingManagePage.tsx
@@ -1,10 +1,13 @@
-import { useState,useEffect, useMemo } from "react";
+import { useState,useEffect } from "react";
 import { useNavigate,useLocation, useParams } from "react-router-dom";
 import { useStaffCheck } from "../../hooks/BookClub/useStaffCheck";
-import { useClubgetMembers } from "../../hooks/BookClub/useClubgetMembers";
-import type { ClubMember } from '../../types/Club/GetClubMembers';
+import { useGetInfinityMember } from "../../hooks/Meeting/useGetInfinityMember"
 import { useMeetingTeamMutate } from "../../hooks/Meeting/useSetMeetingTeam.ts";
 import { buildMeetingTeamMutateRequest } from "../../components/Meeting/teamMapper.ts";
+import type { MeetingMemberItem } from "../../types/Meeting/GetmeetingMember.ts";
+import type { ModalButton } from "../../components/Modal.tsx";
+
+import Modal from "../../components/Modal.tsx";
 export default function DetailMeetingManagePage() {
   const params = useParams<{ bookclubId: string, meetingId: string }>();
   const { state } = useLocation();
@@ -15,24 +18,52 @@ export default function DetailMeetingManagePage() {
   const { data: isStaff, isLoading, isError } = useStaffCheck(params.bookclubId!);
 
   const [groups, setGroups] = useState<string[]>([]);
-  const [participants,setparticipants] = useState<ClubMember[]>([]);
-  const [groupSelections, setGroupSelections] = useState<Record<string, ClubMember[]>>({});
-
-  const {  data: Result,  fetchNextPage,  hasNextPage,  isFetchingNextPage,} =  useClubgetMembers({
-    clubId: Number(params.bookclubId),
-    status: 'ALL',
-    size: 10
-  });
-
+  const [participants, setparticipants] = useState<MeetingMemberItem[]>([]);
+  const [groupSelections, setGroupSelections] = useState<Record<string, MeetingMemberItem[]>>({});
+ 
+  const {data : result, fetchNextPage,  hasNextPage,  isFetchingNextPage} = useGetInfinityMember(Number(meetingId), 15);
   useEffect(() => {
-      if (!Result){return;}
-      const List = Result.pages.flatMap(page => page.clubMembers);
-      // if clubMemberStatus == PENDING,BLOCKED
-      const filteredList = List.filter(member =>
-        member.clubMemberStatus !== 'PENDING' && member.clubMemberStatus !== 'BLOCKED'
-      );
-      setparticipants(filteredList);
-    }, [Result]);
+      if (!hasNextPage || isLoading || isFetchingNextPage) return;
+      fetchNextPage();
+  }, [hasNextPage, isLoading, isFetchingNextPage, fetchNextPage]);
+
+  const [infoOpen, setInfoOpen] = useState(false);
+  const infoTitle ="저장이 완료되었습니다."
+  const infoButton : ModalButton[] = [
+    {
+        label: "확인",
+        onClick: () => {
+          setInfoOpen(false);
+          window.location.reload();
+        }
+    }
+  ];
+  useEffect(() => {
+  if (!result) return;
+
+  const flatMembers = result.pages.flatMap(p => p.members);
+  setparticipants(flatMembers);
+  const toLabel = (i: number) => `${String.fromCharCode(65 + i)}조`;
+  const assigned = flatMembers.filter(
+    m => typeof m.teamNumber === 'number' && m.teamNumber > 0
+  );
+
+  const maxGroup = Math.max(...assigned.map(m => m.teamNumber!)); 
+  const groupsArr = Array.from({ length: maxGroup }, (_, i) => toLabel(i));
+
+  const initialGroup: Record<string, MeetingMemberItem[]> = {};
+  for (const g of groupsArr) initialGroup[g] = [];
+
+  for (const m of assigned) {
+    const label = toLabel(m.teamNumber! - 1); 
+    initialGroup[label].push(m);
+  }
+
+  setGroups(groupsArr);
+  setGroupSelections(initialGroup);
+}, [result]);
+
+
 
   
   const addGroup = () => {
@@ -43,26 +74,38 @@ export default function DetailMeetingManagePage() {
 
   const removeGroup = (groupName: string) => {
     setGroups((prev) => prev.filter((name) => name !== groupName));
+    setGroupSelections(prev => {
+      const newSelections = { ...prev };
+      delete newSelections[groupName];
+      return newSelections;
+    });
   };
   
+  const removeMemberFromGroup = (groupName: string, membername: string) => {
+    setGroupSelections(prev => {
+      const current = prev[groupName] ?? [];
+      const nextArr = current.filter(m => m.memberInfo.nickname !== membername);
+      return { ...prev, [groupName]: nextArr };
+    });
+  };
 
   const toggleGroup = (userIdx: number, groupName: string) => {
   const member = participants[userIdx];
   if (!member) return;
-  const id = member.clubMemberId;
+  const nickname = member.memberInfo.nickname;
 
   setGroupSelections(prev => {
-      const next: Record<string, ClubMember[]> = {};
+      const next: Record<string, MeetingMemberItem[]> = {};
       for (const [g, arr] of Object.entries(prev)) {
-        next[g] = arr.filter(m => m.clubMemberId !== id);
+        next[g] = arr.filter(m => m.memberInfo.nickname !== nickname);
       }
 
       const target = next[groupName] ?? [];
-      const alreadyInTarget = target.some(m => m.clubMemberId === id);
+      const alreadyInTarget = target.some(m => m.memberInfo.nickname === nickname);
 
       if (alreadyInTarget) {
 
-        const trimmed = target.filter(m => m.clubMemberId !== id);
+        const trimmed = target.filter(m => m.memberInfo.nickname !== nickname);
         if (trimmed.length) next[groupName] = trimmed;
         else delete next[groupName]; // 깔끔하게 비우기
       } else {
@@ -73,41 +116,30 @@ export default function DetailMeetingManagePage() {
     });
   };
 
-  const getMembersInGroup = (groupName: string): ClubMember[] => {
+  const getMembersInGroup = (groupName: string): MeetingMemberItem[] => {
     return groupSelections[groupName] ?? [];
   };
   
-  
-  useEffect(() => {
-      if (!hasNextPage || isLoading || isFetchingNextPage) return;
-      fetchNextPage();
-  }, [hasNextPage, isLoading, isFetchingNextPage, fetchNextPage]);
-
-
   const { mutate: saveTeams } = useMeetingTeamMutate(Number(meetingId));
-  const payload = useMemo(
-    () => buildMeetingTeamMutateRequest(groupSelections, groups),
-    [groupSelections, groups]
-  );
-  useEffect(() => {
+  const handleSend = () => {
+    const payload = buildMeetingTeamMutateRequest(groupSelections);
     if (payload.teamMemberDTOList.length === 0) return;
+    console.log("Saving teams:", payload);
     saveTeams(payload);
-  }, [groupSelections]);
+  };
 
   if(!isStaff)return <div>권한이 없습니다!</div>;
   if(isLoading) return <div>Loading...</div>;
   if(isError) return <div>Error occurred</div>;
-
+  
   return (
-    <div className="flex w-full min-h-screen bg-[#FAFAFA] overflow-y-auto bg-white">
+    <div className="flex min-h-screen bg-[#FAFAFA] overflow-y-auto bg-white">
       <main className="flex-1 px-10 py-[30px]">
-        {/* 상단 뒤로가기 영역 */}
+
         <div onClick={() => navigate(-1)} className="flex items-center h-[38px] gap-[3px] cursor-pointer mb-[36px]">
-          {/* 1) 왼쪽 아이콘 영역 (30px) */}
           <div className="w-[30px] h-full flex items-center justify-center">
             <img src="/assets/material-symbols_arrow-back-ios.svg" className="w-[30px] h-[30px]"/>
           </div>
-          {/* 2) 책 이름 */}
           <span className="font-[Pretendard] font-bold text-[28px] leading-[135%]">
             {meetingTitle}
           </span>
@@ -125,17 +157,21 @@ export default function DetailMeetingManagePage() {
                 <div className = 'flex justify-between font-semibold text-lg mb-2'>
                   <p className="">{groupName}</p>
                 { groups.length-1 == idx &&
-                  <button onClick={() => removeGroup(groupName)} className="text-red-500 hover:underline">삭제</button>
+                  <button onClick={() => removeGroup(groupName)} className="text-red-500 hover:underline cursor-pointer">삭제</button>
                 }
                 </div>
                 <hr className="border-t border-[#EAE5E2] mb-2" />
                 <div className="grid grid-cols-1 gap-y-2">
-                  {getMembersInGroup(groupName).map((member : ClubMember) => (
+                  {getMembersInGroup(groupName).map((member : MeetingMemberItem) => (
                     <div
-                      className="bg-[#F4F2F1] w-[365px] h-[44px] rounded-[20px] flex items-center px-3 text-[17px] font-medium text-[#2C2C2C] truncate"
+                      className="bg-[#F4F2F1] w-[365px] h-[44px] rounded-[20px] flex items-center px-3 text-[17px] font-medium text-[#2C2C2C] truncate cursor-pointer hover:shadow-sm"
+                      onClick={() => {
+                        removeMemberFromGroup(groupName, member.memberInfo.nickname);
+                      }}
                     >
-                      <img src={member.basicInfo.profileImageUrl} className="w-[32px] h-[32px] rounded-full bg-[#DADADA] mr-5 text-[var(--Gray-1,#2C2C2C)] font-pretendard text-[18px] font-medium leading-[135%]" />
-                      {member.basicInfo.nickname}
+                      <img src={member.memberInfo.profileImageUrl || "/assets/basic_profile.png"}
+                      className="w-[32px] h-[32px] rounded-full mr-5 text-[var(--Gray-1,#2C2C2C)] font-pretendard text-[18px] font-medium leading-[135%]" />
+                      {member.memberInfo.nickname}
                     </div>
                   ))}
                 </div>
@@ -146,7 +182,7 @@ export default function DetailMeetingManagePage() {
             {groups.length !== 6 && (
               <button
                 onClick={addGroup}
-                className="w-[400px] h-[44px] bg-[#F4F2F1] rounded-[16px] text-[#2C2C2C] text-lg font-medium"
+                className="w-[400px] h-[44px] bg-[#F4F2F1] rounded-[16px] text-[#2C2C2C] text-lg font-medium cursor-pointer"
               >
                 +
               </button>
@@ -158,25 +194,25 @@ export default function DetailMeetingManagePage() {
             <h2 className="text-[#2C2C2C] text-[18px] font-medium mb-5">
               토론 참여자
             </h2>
-
-            <div className="bg-white border-[2px] border-[#EAE5E2] rounded-[12px] p-6 min-h-[540px]" >
+            <div className="min-h-[600px] bg-white border-[2px] border-[#EAE5E2] rounded-[12px] p-6 min-h-[540px]" >
               <div className="space-y-4">
-                {participants.map((member: ClubMember) => (
+                {participants.map((member: MeetingMemberItem) => (
                   <div className="flex items-center justify-between border-b border-[#EAE5E2] pb-3">
                     <div className="flex items-center gap-4 min-w-[180px]">
-                      <img src={member.basicInfo.profileImageUrl} className="w-[36px] h-[36px] rounded-full bg-[#DADADA]" />
+                      <img src={member.memberInfo.profileImageUrl || "/assets/basic_profile.png"}
+                      className="w-[36px] h-[36px] rounded-full" />
                       <span className="text-[#2C2C2C] text-lg font-medium truncate">
-                        {member.basicInfo.nickname}
+                        {member.memberInfo.nickname}
                       </span>
                     </div>
 
-                    <div className="grid grid-cols-6 gap-x-2 gap-y-2">
+                    <div className="flex flex-wrap gap-2 justify-end flex-1">
                       {groups.map((group) => {
-                        const isSelected = groupSelections[group]?.includes(member);
+                        const isSelected = (groupSelections[group] ?? []).some(m => m.memberInfo.nickname === member.memberInfo.nickname);
                         return (
                           <button
                             onClick={() => toggleGroup(participants.indexOf(member), group)}
-                            className={`w-[58px] h-[36px] rounded-full border text-[14px] font-medium border-[#90D26D] text-[#3D4C35]
+                            className={`w-[58px] h-[36px] rounded-full border text-[14px] font-medium border-[#90D26D] text-[#3D4C35] cursor-pointer hover:shadow-md
                               ${isSelected? " bg-[#90D26D]" : " bg-[#EFF5ED]"}`
                             }
                           >
@@ -191,8 +227,23 @@ export default function DetailMeetingManagePage() {
                 <div/>
 
             </div>
+           <div className = "flex  justify-end ">
+            <button className = "mt-[18px] w-[90px] h-[35px] px-3 py-[5px] justify-center items-center gap-[10px] shrink-0 rounded-[16px]  text-sm font-medium bg-[#DED6CD] text-[#A6917D] hover:bg-[#A6917D] hover:text-white" onClick={() => {
+              handleSend();
+              setInfoOpen(true);
+            }}>
+              저장하기
+            </button> 
+           </div>
           </div>
+          
         </div>
+        <Modal
+        isOpen={infoOpen}
+        title={infoTitle}
+        buttons={infoButton}
+        onBackdrop={() => setInfoOpen(false)}
+      />
       </main>
     </div>
   );

--- a/src/types/Meeting/GetmeetingMember.ts
+++ b/src/types/Meeting/GetmeetingMember.ts
@@ -1,0 +1,33 @@
+import type { ApiResponse } from "../../types/apiResponse";
+
+export interface Membership {
+  clubMemberId: number;
+  clubMemberStatus: 'MEMBER' | 'BLOCKED' | 'STAFF';
+  updatedAt: string; 
+}
+
+export interface MemberInfo {
+  nickname: string;
+  profileImageUrl: string;
+}
+
+export interface MeetingMemberItem {
+  memberInfo: MemberInfo;
+  teamNumber: number;
+}
+
+export interface GetMeetingMembersPayload {
+  meetingId: number;              
+  cursorId?: number | null;     
+  size?: number;             
+}
+
+export interface GetMeetingMembersData {
+  membership: Membership;
+  members: MeetingMemberItem[];
+  hasNext: boolean;
+  nextCursor: number | null;
+}
+
+export type GetMeetingMembersResponse = ApiResponse<GetMeetingMembersData>;
+export type GetMeetingMembersResult   = GetMeetingMembersResponse['result'];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 모임 멤버 무한 스크롤 조회 훅과 API 추가로 멤버 목록을 페이지네이션으로 로드.
  - 모임 관리 페이지에 멤버 그룹핑 UI 개선, 저장 완료 안내 모달 및 이미지 기본값 제공.

- 버그 수정
  - 프로필 이미지가 없을 때 기본 아이콘으로 대체.
  - 닉네임/프로필 일부 누락 시에도 가능한 정보만 반영하도록 초기화 로직 완화.

- 리팩터
  - 모임 멤버 데이터 모델로 전환하고 팀 요청 빌더 시그니처 단순화(그룹 배열 인자 제거).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->