### PR TITLE
[style] 기본 이미지 배율 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -168,7 +168,7 @@ const Header = ({
               <img
                 src="/assets/basic_profile.png"
                 alt="기본 프로필"
-                className="w-full h-full object-cover"
+                className="w-full h-full object-cover scale-125"
               />
             )}
           </div>

--- a/src/pages/Auth/ProfilePage.tsx
+++ b/src/pages/Auth/ProfilePage.tsx
@@ -19,11 +19,6 @@ const ProfilePage = () => {
     const isLoggedIn = Boolean(localStorage.getItem("nickname"));
     const blockedPaths = ["/", "/signup", "/profile"];
 
-    //  /profile 주소 직접 접근 차단
-    if (location.pathname === "/profile") {
-      navigate("/", { replace: true });
-      return;
-    }
 
     if (isLoggedIn && blockedPaths.includes(location.pathname)) {
       (async () => {
@@ -249,14 +244,16 @@ const ProfilePage = () => {
                       <img
                         src={profileImagePreview}
                         alt="Profile"
-                        className="w-full h-full object-cover"
+                        className={`w-full h-full object-cover ${
+                          profileImagePreview === "/assets/basic_profile.png" ? "scale-125" : ""
+                        }`}
                         onError={(e) => {
                           e.currentTarget.src = "/assets/basic_profile.png";
-                          e.currentTarget.style.objectFit = "cover";  // 기본 이미지도 꽉 차게
+                          e.currentTarget.classList.add("scale-125");
                         }}
                       />
                     ) : (
-                      <div className="w-full h-full bg-[#F8FFEF]" />
+                      <div className="w-full h-full bg-[#F7FFE9]" />
                     )}
                   </div>
 
@@ -444,16 +441,19 @@ const ProfilePage = () => {
                     <img
                       src={profileImagePreview}
                       alt="Profile"
-                      className="w-full h-full object-cover"
+                      className={`w-full h-full object-cover ${
+                        profileImagePreview === "/assets/basic_profile.png" ? "scale-125" : ""
+                      }`}
                       onError={(e) => {
                         e.currentTarget.src = "/assets/basic_profile.png";
+                        e.currentTarget.classList.add("scale-125");
                       }}
                     />
                   ) : (
                     <img
                       src="/assets/basic_profile.png"
                       alt="Default Profile"
-                      className="w-full h-full object-cover"
+                      className="w-full h-full object-cover scale-125"
                     />
                   )}
                 </div>

--- a/src/pages/Auth/SignupPage.tsx
+++ b/src/pages/Auth/SignupPage.tsx
@@ -270,12 +270,12 @@ const SignupPage = () => {
                 {/* 이메일 입력 */}
                 <div className="mb-7">
                   <label className="block mb-3 text-[#2C2C2C] text-sm font-semibold">
-                    아이디
+                    이메일
                   </label>
                   <div className="flex gap-2">
                     <input
                       type="text"
-                      placeholder="이메일 아이디"
+                      placeholder="이메일"
                       value={emailId}
                       onChange={(e) => setEmailId(e.target.value)}
                       className="flex-1 border-b border-[#DADFE3] px-3 py-1 focus:outline-none"

--- a/src/pages/Main/Info/My/MyProfilePage.tsx
+++ b/src/pages/Main/Info/My/MyProfilePage.tsx
@@ -23,7 +23,6 @@ const MyProfilePage = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-
   const [errorModal, setErrorModal] = useState<{ isOpen: boolean; message: string }>({
     isOpen: false,
     message: "",
@@ -54,14 +53,23 @@ const MyProfilePage = () => {
   );
   const keywords: string[] = useMemo(() => CATEGORY_ENTRIES.map((e) => e.name), [CATEGORY_ENTRIES]);
 
+ // 프로필 초기화 부분
   useEffect(() => {
     if (!me) return;
+
     setNickname(me.nickname ?? "");
     const desc = me.description ?? "";
     setBio(desc);
     setTempBio(desc);
-    setProfileImage(me.profileImageUrl ?? null);
-    setTempProfileImage(me.profileImageUrl ?? null);
+
+    // 여기서 null/빈값 처리 → 기본이미지 강제
+    const img = me.profileImageUrl && me.profileImageUrl.trim() !== ""
+      ? me.profileImageUrl
+      : "/assets/basic_profile.png";
+
+    setProfileImage(img);
+    setTempProfileImage(img);
+
     const names = (me.categories ?? []).map((c: { id: number; name: string }) => c.name);
     setTempKeywords(names);
   }, [me]);
@@ -169,15 +177,18 @@ const MyProfilePage = () => {
                   className="w-[212px] h-[212px] rounded-full overflow-hidden flex items-center justify-center border cursor-pointer"
                   style={{ borderColor: "#EAE5E2", backgroundColor: "#F4F2F1" }}
                 >
-                  {tempProfileImage ? (
-                    <img src={tempProfileImage} alt="프로필" className="w-full h-full object-cover" />
-                  ) : (
-                    <img
-                      src="/assets/basic_profile.png"
-                      alt="기본 프로필"
-                      className="w-full h-full object-cover"
-                    />
-                  )}
+                  <img
+                    src={tempProfileImage ?? "/assets/basic_profile.png"}
+                    alt="프로필"
+                    onError={(e) => {
+                      e.currentTarget.src = "/assets/basic_profile.png"; 
+                    }}
+                    className={`w-full h-full object-cover ${
+                      (tempProfileImage ?? "/assets/basic_profile.png") === "/assets/basic_profile.png"
+                        ? "scale-125"
+                        : ""
+                    }`}
+                  />
                 </div>
                 {isEditing && (
                   <label


### PR DESCRIPTION
기본 이미지 여백 수정

- 프로필페이지 기본이미지 수정
- 마이프로필페이지 기본이미지 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * /profile 경로에서 발생하던 무조건 홈으로 이동되는 리다이렉션을 제거하여 프로필 페이지 접근이 정상화되었습니다.
  * 프로필 이미지 로딩 실패 시 기본 이미지로 안전하게 대체되도록 처리 일관성을 강화했습니다. (여러 화면)
* Style
  * 기본 프로필 이미지에 확대(scale-125)를 적용하고 오류 시에도 동일하게 확대되도록 통일했습니다. (헤더, 프로필 화면)
  * 프로필 플레이스홀더 배경색을 #F7FFE9로 미세 조정했습니다.
  * 회원가입 STEP 1 레이블/플레이스홀더를 “아이디”에서 “이메일”로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->