### PR TITLE
[feat] 책이야기 삭제 후 redirect 동적으로 변경

### DIFF
--- a/src/pages/Main/BookStory/BookStoryDetailPage.tsx
+++ b/src/pages/Main/BookStory/BookStoryDetailPage.tsx
@@ -82,7 +82,7 @@ export default function BookStoryDetailPage() {
     try {
       await deleteBookStory(Number(storyId));
       setIsModalOpen(false);
-      navigate(-2); // 이전 페이지(원래 있던 페이지)로 이동
+      navigate(-1); // 이전 페이지(원래 있던 페이지)로 이동
     } catch (err) {
       console.error(err);
       alert("삭제 실패했습니다.");

--- a/src/pages/Main/BookStory/BookStoryDetailPage.tsx
+++ b/src/pages/Main/BookStory/BookStoryDetailPage.tsx
@@ -82,7 +82,7 @@ export default function BookStoryDetailPage() {
     try {
       await deleteBookStory(Number(storyId));
       setIsModalOpen(false);
-      navigate("/bookstory/my");
+      navigate(-2); // 이전 페이지(원래 있던 페이지)로 이동
     } catch (err) {
       console.error(err);
       alert("삭제 실패했습니다.");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 도서 스토리 상세 페이지에서 항목 삭제 후, 고정된 “내 스토리” 페이지로 이동하던 동작을 수정했습니다. 이제 삭제 시 사용자가 오기 전 페이지(브라우저 히스토리의 바로 이전 화면)로 돌아갑니다. 이를 통해 흐름이 끊기지 않고, 목록/검색/필터 등 사용자가 보던 맥락을 그대로 유지할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->