### PR TITLE
Revert "Update NonProfileHeader.tsx"

### DIFF
--- a/src/components/NonProfileHeader.tsx
+++ b/src/components/NonProfileHeader.tsx
@@ -11,7 +11,7 @@ const NonProfileHeaderComponent = ({ title }: NonProfileHeaderProps) => {
 
   return (
     <div className="flex items-center sticky top-0 z-30 bg-white min-w-[700px] py-[30px]">
-      <button onClick={() => navigate(-1)} className="mr-2 h-6 w-6 cursor-pointer ">
+      <button onClick={() => navigate(-1)} className="mr-2 h-6 w-6 cursor-pointer">
         <img src={backIcon} alt="뒤로가기" />
       </button>
       <h1 className="text-2xl font-bold truncate">{title}</h1>


### PR DESCRIPTION
Reverts checkmo2025/CHECKMO-FE#380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 헤더의 뒤로가기 버튼 className에서 불필요한 공백을 제거해 코드 일관성을 개선했습니다.
  * UI의 시각적 결과, 레이아웃, 클릭 동작에는 변화가 없습니다.
  * 유지보수성을 높이고 잠재적 린트 경고를 줄이는 데 도움이 됩니다.
  * 사용자에게 보이는 변경 사항은 없으며 기존 흐름은 그대로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->