### PR TITLE
style : meeting페이지

### DIFF
--- a/src/components/Meeting/TeamButtonList.tsx
+++ b/src/components/Meeting/TeamButtonList.tsx
@@ -31,7 +31,7 @@ const TeamButtonListComponent = ({
                 }
                 onSelect(teamNumber);
               }}
-              className={`px-4 py-1.5 border-2 text-xs rounded-xl whitespace-nowrap ${isSelected
+              className={`px-4 py-1.5 border-2 text-xs rounded-xl whitespace-nowrap cursor-pointer ${isSelected
                 ? "border-[#90D26D] bg-[#90D26D] text-white"
                 : "border-[#90D26D]  bg-[#EFF5ED] text-[#3D4C35]"
                 }`}

--- a/src/components/Meeting/TeamTopicParticipant.tsx
+++ b/src/components/Meeting/TeamTopicParticipant.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import type { AuthorDto } from "../../types/dto";
 
 interface TeamTopicParticipantProps {
@@ -9,6 +10,7 @@ const TeamTopicParticipant = ({
   teamName,
   participants,
 }: TeamTopicParticipantProps) => {
+  const navigate = useNavigate();
   return (
     <>
       <h2 className="text-base font-semibold mb-3">{String.fromCharCode(64 + teamName)}조 참여자</h2>
@@ -20,9 +22,10 @@ const TeamTopicParticipant = ({
               className="flex items-center mt-2 p-2 border-b-2 border-gray-200"
             >
               <img
-                src={p.profileImageUrl ?? "/default-avatar.png"}
+                src={p.profileImageUrl || "/src/assets/images/userImage.png"}
                 alt={p.nickname}
                 className="w-8 h-8 rounded-full bg-gray-200 flex-shrink-0"
+                onClick={() => navigate(`/info/others/${p.nickname}`)}
               />
               <span className="ml-3 text-md font-medium text-black">
                 {p.nickname}

--- a/src/components/Meeting/TeamTopicSection.tsx
+++ b/src/components/Meeting/TeamTopicSection.tsx
@@ -23,7 +23,7 @@ const TeamTopicSectionComponent = ({
         {onViewAllClick && (
           <button
             onClick={onViewAllClick}
-            className="text-sm text-gray-500 hover:underline"
+            className="text-sm text-gray-500 hover:underline cursor-pointer"
           >
             전체보기
           </button>

--- a/src/components/Meeting/TopicCard.tsx
+++ b/src/components/Meeting/TopicCard.tsx
@@ -17,7 +17,7 @@ const TopicCardComponent = ({ content, authorInfo }: TopicCardProps) => {
           src={authorInfo.profileImageUrl ? authorInfo.profileImageUrl : defaultAvatar}
           alt={authorInfo.nickname}
           onClick={() => navigate(`/info/others/${authorInfo.nickname}`)}
-          className="w-8 h-8 rounded-full bg-gray-200 shrink-0 ml-2"
+          className="w-8 h-8 rounded-full shrink-0 ml-2 cursor-pointer"
         />
         <span className="text-black text-[12px] font-medium w-[120px] shrink-0 overflow-hidden text-ellipsis whitespace-nowrap">
           {authorInfo.nickname}

--- a/src/components/Meeting/TopicPreviewSection.tsx
+++ b/src/components/Meeting/TopicPreviewSection.tsx
@@ -25,7 +25,7 @@ const TopicPreviewSectionComponent = ({
         {onMoreClick && (
           <button
             onClick={onMoreClick}
-            className="text-sm text-gray-500 hover:underline"
+            className="text-sm text-gray-500 hover:underline cursor-pointer"
           >
             더보기
           </button>

--- a/src/components/NonProfileHeader.tsx
+++ b/src/components/NonProfileHeader.tsx
@@ -11,7 +11,7 @@ const NonProfileHeaderComponent = ({ title }: NonProfileHeaderProps) => {
 
   return (
     <div className="flex items-center sticky top-0 z-30 bg-white min-w-[700px] py-[30px]">
-      <button onClick={() => navigate(-1)} className="mr-2 h-6 w-6">
+      <button onClick={() => navigate(-1)} className="mr-2 h-6 w-6 cursor-pointer">
         <img src={backIcon} alt="뒤로가기" />
       </button>
       <h1 className="text-2xl font-bold truncate">{title}</h1>

--- a/src/pages/Meeting/DetailMeatingManagePage.tsx
+++ b/src/pages/Meeting/DetailMeatingManagePage.tsx
@@ -8,6 +8,7 @@ import type { MeetingMemberItem } from "../../types/Meeting/GetmeetingMember.ts"
 import type { ModalButton } from "../../components/Modal.tsx";
 
 import Modal from "../../components/Modal.tsx";
+import { NonProfileHeader } from "../../components/NonProfileHeader.tsx";
 export default function DetailMeetingManagePage() {
   const params = useParams<{ bookclubId: string, meetingId: string }>();
   const { state } = useLocation();
@@ -134,16 +135,8 @@ export default function DetailMeetingManagePage() {
   
   return (
     <div className="flex min-h-screen bg-[#FAFAFA] overflow-y-auto bg-white">
-      <main className="flex-1 px-10 py-[30px]">
-
-        <div onClick={() => navigate(-1)} className="flex items-center h-[38px] gap-[3px] cursor-pointer mb-[36px]">
-          <div className="w-[30px] h-full flex items-center justify-center">
-            <img src="/assets/material-symbols_arrow-back-ios.svg" className="w-[30px] h-[30px]"/>
-          </div>
-          <span className="font-[Pretendard] font-bold text-[28px] leading-[135%]">
-            {meetingTitle}
-          </span>
-        </div>
+      <main className="flex-1 px-10">
+        <NonProfileHeader title={meetingTitle} />
 
         <div className="flex flex-col lg:flex-row gap-10">
           {/* 왼쪽: 조 생성 + 멤버 배정 */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 토픽 및 참여자 아바타를 클릭하면 해당 사용자 프로필 페이지로 이동합니다.
- UX 개선
  - “전체보기”, “더보기”, 팀 선택 버튼, 뒤로가기 아이콘, 아바타 등에 포인터 커서가 표시되어 클릭 가능성이 명확해졌습니다.
  - 토픽 카드의 아바타 배경을 정리하여 더 깔끔한 표시로 개선했습니다.
- 리팩터
  - 미팅 관리 상세 페이지 상단 헤더를 공용 헤더로 통합해 일관된 레이아웃과 스타일을 제공하며, 기능적 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->