### PR TITLE
[fix] 모임 많은 경우 모달 스크롤 되도록

### DIFF
--- a/src/components/BookClubListModal.tsx
+++ b/src/components/BookClubListModal.tsx
@@ -31,7 +31,7 @@ const BookClubListModal = ({ isOpen, clubs, onClose, onSelect }: Props) => {
   return (
     <div
       ref={ref}
-      className="absolute left-[15rem] top-40 w-48 bg-white border border-gray-200 shadow-lg rounded-md z-50"
+      className="absolute left-[15rem] top-40 w-48 max-h-60 overflow-y-auto bg-white border border-gray-200 shadow-lg rounded-md z-50"
     >
       <ul className="flex flex-col">
         {clubs.map((club) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - BookClubListModal에 최대 높이를 적용하고 콘텐츠 초과 시 세로 스크롤이 표시되도록 조정했습니다.
  - 리스트가 길어도 모달이 화면을 과도하게 차지하지 않으며, 내용은 스크롤로 확인할 수 있습니다.
  - 다양한 화면 크기에서 모달 표시가 보다 일관되게 유지됩니다.
  - 기존 동작(외부 클릭 닫기, 열기/닫기 제어, 선택/닫기 처리)은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->